### PR TITLE
i286: Improve MCP tool output: decode HTML, add signatures + samples

### DIFF
--- a/src/WebDocs/Helpers/DrapoDocContent.cs
+++ b/src/WebDocs/Helpers/DrapoDocContent.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using WebDocs.Models;
+
+namespace WebDocs.Helpers
+{
+    /// <summary>
+    /// Converts the raw HTML documentation stored on disk into clean Markdown/plain text
+    /// suitable for MCP (LLM) consumption: no BOM, no raw HTML tags, decoded entities.
+    /// Also builds human-readable function signatures from parameter metadata.
+    /// </summary>
+    public static class DrapoDocContent
+    {
+        private static readonly Regex TagRegex = new Regex("<[^>]+>", RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex MultiBlankLine = new Regex(@"\n{3,}", RegexOptions.Compiled);
+        private static readonly Regex TrailingSpaces = new Regex(@"[ \t]+\n", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Converts documentation HTML (prose) to Markdown: strips BOM, maps common tags to
+        /// Markdown, removes remaining tags, decodes entities, and normalizes whitespace.
+        /// Code/pre blocks are preserved verbatim (decoded) so examples are not mangled.
+        /// </summary>
+        public static string ToMarkdown(string html)
+        {
+            if (string.IsNullOrWhiteSpace(html))
+                return html?.Trim();
+
+            string text = StripBom(html);
+
+            // Preserve code blocks first so the tag-stripping pass below can't damage examples.
+            var preserved = new List<string>();
+            text = Regex.Replace(text, @"<pre[^>]*>(.*?)</pre>", m =>
+            {
+                string code = WebUtility.HtmlDecode(StripTags(m.Groups[1].Value)).Trim();
+                preserved.Add("\n```\n" + code + "\n```\n");
+                return PlaceHolder(preserved.Count - 1);
+            }, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            text = Regex.Replace(text, @"<code[^>]*>(.*?)</code>", m =>
+            {
+                string code = WebUtility.HtmlDecode(StripTags(m.Groups[1].Value));
+                preserved.Add("`" + code + "`");
+                return PlaceHolder(preserved.Count - 1);
+            }, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            // Block / inline tags -> Markdown.
+            text = Regex.Replace(text, @"<br\s*/?>", "\n", RegexOptions.IgnoreCase);
+            text = Regex.Replace(text, @"<h1[^>]*>(.*?)</h1>", "\n# $1\n", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            text = Regex.Replace(text, @"<h2[^>]*>(.*?)</h2>", "\n## $1\n", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            text = Regex.Replace(text, @"<h3[^>]*>(.*?)</h3>", "\n### $1\n", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            text = Regex.Replace(text, @"<h[4-6][^>]*>(.*?)</h[4-6]>", "\n#### $1\n", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            text = Regex.Replace(text, @"</?(strong|b)\s*>", "**", RegexOptions.IgnoreCase);
+            text = Regex.Replace(text, @"</?(em|i)\s*>", "*", RegexOptions.IgnoreCase);
+            text = Regex.Replace(text, @"<li[^>]*>(.*?)</li>", "- $1\n", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            text = Regex.Replace(text, @"<a[^>]*>(.*?)</a>", "$1", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            text = Regex.Replace(text, @"<p[^>]*>", "\n", RegexOptions.IgnoreCase);
+            text = Regex.Replace(text, @"</p>", "\n", RegexOptions.IgnoreCase);
+
+            // Strip anything left, decode remaining entities, normalize whitespace.
+            text = StripTags(text);
+            text = WebUtility.HtmlDecode(text);
+            text = Normalize(text);
+
+            // Restore preserved code blocks.
+            for (int i = 0; i < preserved.Count; i++)
+                text = text.Replace(PlaceHolder(i), preserved[i]);
+
+            return text.Trim();
+        }
+
+        /// <summary>
+        /// Cleans a literal code sample (Drapo HTML markup) for LLM consumption: strips BOM,
+        /// normalizes line endings, and trims. The markup itself is preserved verbatim.
+        /// </summary>
+        public static string CleanCode(string code)
+        {
+            if (string.IsNullOrWhiteSpace(code))
+                return code?.Trim();
+            return StripBom(code).Replace("\r\n", "\n").Replace("\r", "\n").Trim();
+        }
+
+        /// <summary>
+        /// Builds a one-line, human-readable signature from a function's parameters,
+        /// e.g. <c>UpdateSector(SectorName: text, Url: url, [Title: text = null])</c>.
+        /// Optional parameters are wrapped in brackets with their default value.
+        /// </summary>
+        public static string BuildFunctionSignature(string name, List<FunctionParameterVM> parameters)
+        {
+            var sb = new StringBuilder();
+            sb.Append(name).Append('(');
+            if (parameters != null)
+            {
+                for (int i = 0; i < parameters.Count; i++)
+                {
+                    if (i > 0)
+                        sb.Append(", ");
+                    FunctionParameterVM p = parameters[i];
+                    string types = (p.Types != null && p.Types.Count > 0) ? string.Join("|", p.Types) : "any";
+                    string core = $"{p.Name}: {types}";
+                    if (p.Optional)
+                    {
+                        string def = string.IsNullOrEmpty(p.DefaultValue) ? "" : $" = {p.DefaultValue}";
+                        sb.Append('[').Append(core).Append(def).Append(']');
+                    }
+                    else
+                    {
+                        sb.Append(core);
+                    }
+                }
+            }
+            sb.Append(')');
+            return sb.ToString();
+        }
+
+        private static string StripTags(string value) => TagRegex.Replace(value, "");
+
+        private static string StripBom(string value) => value.Replace("﻿", "").Replace("​", "");
+
+        private static string PlaceHolder(int index) => $"PRESERVED{index}";
+
+        private static string Normalize(string text)
+        {
+            text = text.Replace("\r\n", "\n").Replace("\r", "\n");
+            text = TrailingSpaces.Replace(text, "\n");
+            text = MultiBlankLine.Replace(text, "\n\n");
+            return text;
+        }
+    }
+}

--- a/src/WebDocs/Models/FunctionVM.cs
+++ b/src/WebDocs/Models/FunctionVM.cs
@@ -16,6 +16,12 @@ namespace WebDocs.Models
         /// </summary>
         public string Description { set; get; }
         /// <summary>
+        /// A one-line, human-readable signature synthesized from the parameters,
+        /// e.g. "UpdateSector(SectorName: text, Url: url, [Title: text = null])".
+        /// Populated only when details are requested.
+        /// </summary>
+        public string Signature { set; get; }
+        /// <summary>
         /// The list of parameters for the Drapo function.
         /// </summary>
         public List<FunctionParameterVM> Parameters { get; set; }

--- a/src/WebDocs/Services/AttributeService.cs
+++ b/src/WebDocs/Services/AttributeService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using WebDocs.Helpers;
 using WebDocs.Models;
 
 namespace WebDocs.Services
@@ -76,8 +77,8 @@ namespace WebDocs.Services
                 list.Add(new AttributeVM
                 {
                     Name = displayName,
-                    Description = description,
-                    Details = withDetails ? string.Join("\n", lines) : null
+                    Description = DrapoDocContent.ToMarkdown(description),
+                    Details = withDetails ? DrapoDocContent.ToMarkdown(string.Join("\n", lines)) : null
                 });
             }
             return list;

--- a/src/WebDocs/Services/ConceptService.cs
+++ b/src/WebDocs/Services/ConceptService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using WebDocs.Helpers;
 using WebDocs.Models;
 
 namespace WebDocs.Services
@@ -128,7 +129,7 @@ namespace WebDocs.Services
                         details = string.Join("\n", lines);
                 }
 
-                list.Add(new ConceptVM { Name = displayName, Description = description, Details = details });
+                list.Add(new ConceptVM { Name = displayName, Description = DrapoDocContent.ToMarkdown(description), Details = DrapoDocContent.ToMarkdown(details) });
             }
             return list;
         }

--- a/src/WebDocs/Services/DataTypeService.cs
+++ b/src/WebDocs/Services/DataTypeService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using WebDocs.Helpers;
 using WebDocs.Models;
 
 namespace WebDocs.Services
@@ -83,8 +84,8 @@ namespace WebDocs.Services
                 list.Add(new DataTypeVM
                 {
                     Name = displayName,
-                    Description = description,
-                    Details = withDetails ? string.Join("\n", lines) : null
+                    Description = DrapoDocContent.ToMarkdown(description),
+                    Details = withDetails ? DrapoDocContent.ToMarkdown(string.Join("\n", lines)) : null
                 });
             }
             return list;

--- a/src/WebDocs/Services/FunctionService.cs
+++ b/src/WebDocs/Services/FunctionService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using WebDocs.Helpers;
 using WebDocs.Models;
 
 namespace WebDocs.Services
@@ -199,11 +200,13 @@ namespace WebDocs.Services
                 return (null);
             FunctionVM function = new FunctionVM();
             function.Name = name;
-            function.Description = await File.ReadAllTextAsync(descriptionPath);
+            function.Description = DrapoDocContent.ToMarkdown(await File.ReadAllTextAsync(descriptionPath));
             if (loadDetails)
             {
                 // Load parameters
                 function.Parameters = await GetParameters(name);
+                // Synthesize a one-line signature from the parameters
+                function.Signature = DrapoDocContent.BuildFunctionSignature(name, function.Parameters);
                 // Load samples
                 string samplesPath = Path.Combine(path, "samples");
                 var samples = new List<FunctionSampleVM>();
@@ -216,8 +219,8 @@ namespace WebDocs.Services
                         sample.Name = Path.GetFileName(sampleDir);
                         string descFile = Path.Combine(sampleDir, "description.html");
                         string contentFile = Path.Combine(sampleDir, "content.html");
-                        sample.Description = System.IO.File.Exists(descFile) ? await File.ReadAllTextAsync(descFile) : null;
-                        sample.Content = System.IO.File.Exists(contentFile) ? await File.ReadAllTextAsync(contentFile) : null;
+                        sample.Description = System.IO.File.Exists(descFile) ? DrapoDocContent.ToMarkdown(await File.ReadAllTextAsync(descFile)) : null;
+                        sample.Content = System.IO.File.Exists(contentFile) ? DrapoDocContent.CleanCode(await File.ReadAllTextAsync(contentFile)) : null;
                         samples.Add(sample);
                     }
                 }


### PR DESCRIPTION
## What

Improves the payload the Drapo MCP tools return so LLMs comprehend it with less noise and more signal. Closes #286.

## Why

The MCP tools returned the raw documentation HTML stored on disk — full of `<p>`, `<code>`, BOM characters and raw tags — which is pure token noise for an LLM. The most useful structured data (typed signatures, samples) was either buried or not surfaced.

## Changes

- **New `Helpers/DrapoDocContent.cs`** — converts doc HTML to clean Markdown:
  - strips BOM / zero-width chars
  - maps `<p>/<h1-6>/<strong>/<em>/<li>/<a>` to Markdown
  - preserves `<pre>`/`<code>` blocks verbatim (decoded) so examples aren't mangled
  - strips remaining tags, decodes entities, normalizes whitespace
  - `BuildFunctionSignature(...)` synthesizes a one-line signature from parameters
  - `CleanCode(...)` cleans literal sample markup (BOM/whitespace only, markup preserved)
- **`Models/FunctionVM.cs`** — adds a `Signature` field (populated only on details).
- **`Services/FunctionService.cs`** — description → Markdown; `Signature` from `parameters.json`; sample descriptions → Markdown, sample content → `CleanCode`.
- **`Services/{Concept,Attribute,DataType}Service.cs`** — `Description` and `Details` run through the converter.

The website HTML renderer (`CreateContent`/`GetContent`) is intentionally left untouched — only the MCP view-model paths changed.

## Verification

- `dotnet build` succeeds (only pre-existing `FunctionController` ASP0019 warnings).
- Ran the real helper against actual docs for `UpdateSector`, `CreateData`, `FilterData`, `LoadPack`:
  - `UpdateSector(SectorName: text, Url: url, [Title: text = null], [CanRoute: boolean = true], [CanLoadDefaultSectors: boolean = false], [ContainerCode: mustache|text = null])` — exact match to `parameters.json`
  - `CreateData(DataKey: datakey, [Notify: boolean = true], Key: text|mustache, Value: text|mustache)` — mid-list optional handled
  - descriptions render as clean Markdown (no tags/BOM); `LoadPack` shows headings/bold/lists/code-spans
  - sample code preserved verbatim

## Acceptance criteria

- [x] All MCP text outputs return decoded markdown (no HTML entities, no raw tags, no BOM)
- [x] `get_function_details` includes a synthesized signature line
- [x] `get_function_details` includes the typed parameter table from `parameters.json` (already present as `Parameters`)
- [x] `get_function_details` includes at least one decoded sample where samples exist
- [x] Spot-checked against 3+ functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
