### PR TITLE
i285: Add verify_catalog MCP tool (engine vs docs drift)

### DIFF
--- a/src/WebDocs/Models/CatalogDriftVM.cs
+++ b/src/WebDocs/Models/CatalogDriftVM.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+
+namespace WebDocs.Models
+{
+    /// <summary>
+    /// Drift report for a single catalog category (functions or attributes): how the
+    /// documented set compares to the set extracted from the bundled Drapo engine.
+    /// </summary>
+    public class CatalogCategoryDriftVM
+    {
+        /// <summary>Distinct names found in the bundled engine.</summary>
+        public int EngineCount { get; set; }
+        /// <summary>Distinct names found in the documentation.</summary>
+        public int DocumentedCount { get; set; }
+        /// <summary>In the engine but not documented (after the allow-list is applied).</summary>
+        public List<string> Undocumented { get; set; } = new List<string>();
+        /// <summary>Documented but not present in the engine (after the allow-list is applied).</summary>
+        public List<string> Stale { get; set; } = new List<string>();
+        /// <summary>Names that differed but were suppressed by the allow-list.</summary>
+        public List<string> AllowListed { get; set; } = new List<string>();
+        /// <summary>True when there is unsuppressed drift in this category.</summary>
+        public bool HasDrift => (Undocumented.Count > 0) || (Stale.Count > 0);
+    }
+
+    /// <summary>
+    /// Result of verify_catalog: compares the documentation catalog against the Drapo
+    /// engine bundled inside the docs app, so undocumented/stale entries surface to LLMs.
+    /// </summary>
+    public class CatalogDriftVM
+    {
+        /// <summary>Version of the bundled Sysphera.Middleware.Drapo engine that was inspected.</summary>
+        public string EngineVersion { get; set; }
+        /// <summary>Function drift. Authoritative: engine functions are dispatched by an exact name.</summary>
+        public CatalogCategoryDriftVM Functions { get; set; }
+        /// <summary>Attribute drift. Heuristic (see <see cref="AttributesAreHeuristic"/>).</summary>
+        public CatalogCategoryDriftVM Attributes { get; set; }
+        /// <summary>
+        /// Attributes are extracted from engine string literals and include many internal /
+        /// dynamically-prefixed attributes, so attribute drift is best-effort and curated via
+        /// the allow-list. Function drift is exact.
+        /// </summary>
+        public bool AttributesAreHeuristic { get; set; } = true;
+        /// <summary>True when the authoritative (function) drift is non-empty.</summary>
+        public bool HasDrift { get; set; }
+    }
+}

--- a/src/WebDocs/Services/CatalogDriftService.cs
+++ b/src/WebDocs/Services/CatalogDriftService.cs
@@ -1,0 +1,199 @@
+using Microsoft.AspNetCore.Hosting;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Sysphera.Middleware.Drapo;
+using WebDocs.Models;
+
+namespace WebDocs.Services
+{
+    /// <summary>
+    /// Compares the documentation catalog against the Drapo engine bundled in the docs app.
+    /// The engine is read from the embedded <c>drapo.js</c> resource of the
+    /// Sysphera.Middleware.Drapo assembly (the same script the app serves at /drapo.js), so the
+    /// check always runs against the exact engine version the docs ship — no cross-repo access.
+    /// </summary>
+    public class CatalogDriftService : ICatalogDriftService
+    {
+        private readonly IWebHostEnvironment _env;
+        private readonly IFunctionService _functions;
+        private readonly IAttributeService _attributes;
+
+        // Function dispatch in the engine is an exact comparison: functionParsed.Name === 'name'.
+        private static readonly Regex FunctionRegex = new Regex(@"functionParsed\.Name\s*===\s*['""]([a-z0-9_]+)['""]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        // Attributes appear only as string literals (no central dispatch), so this is heuristic.
+        private static readonly Regex AttributeRegex = new Regex(@"['""](d-[a-z][a-z-]*)['""]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // The engine is fixed for the process lifetime, so parse it once.
+        private static readonly object EngineLock = new object();
+        private static HashSet<string> _engineFunctions;
+        private static HashSet<string> _engineAttributes;
+        private static string _engineVersion;
+
+        public CatalogDriftService(IWebHostEnvironment env, IFunctionService functions, IAttributeService attributes)
+        {
+            _env = env;
+            _functions = functions;
+            _attributes = attributes;
+        }
+
+        public async Task<CatalogDriftVM> GetDrift()
+        {
+            EnsureEngineParsed();
+            AllowList allow = await LoadAllowList();
+
+            // Functions: authoritative exact-name diff.
+            var docFunctions = new HashSet<string>(
+                (await _functions.GetNames()).Select(n => n.ToLowerInvariant()));
+            CatalogCategoryDriftVM functions = BuildCategory(
+                _engineFunctions, docFunctions,
+                isSuppressed: name => allow.Functions.ContainsKey(name),
+                allowReasonLookup: name => allow.Functions.GetValueOrDefault(name));
+
+            // Attributes: heuristic diff (string literals + dynamic prefixes).
+            var docAttributes = new HashSet<string>(
+                (await _attributes.GetList()).Select(a => a.Name.ToLowerInvariant()));
+            CatalogCategoryDriftVM attributes = BuildCategory(
+                _engineAttributes, docAttributes,
+                isSuppressed: name => IsSuppressedAttribute(name, allow),
+                allowReasonLookup: name => allow.Attributes.GetValueOrDefault(name));
+
+            return new CatalogDriftVM
+            {
+                EngineVersion = _engineVersion,
+                Functions = functions,
+                Attributes = attributes,
+                AttributesAreHeuristic = true,
+                HasDrift = functions.HasDrift
+            };
+        }
+
+        private static CatalogCategoryDriftVM BuildCategory(
+            HashSet<string> engine, HashSet<string> documented,
+            Func<string, bool> isSuppressed, Func<string, string> allowReasonLookup)
+        {
+            var result = new CatalogCategoryDriftVM
+            {
+                EngineCount = engine.Count,
+                DocumentedCount = documented.Count
+            };
+            foreach (string name in engine.Except(documented).OrderBy(n => n))
+            {
+                if (isSuppressed(name))
+                    result.AllowListed.Add(Describe(name, allowReasonLookup(name)));
+                else
+                    result.Undocumented.Add(name);
+            }
+            foreach (string name in documented.Except(engine).OrderBy(n => n))
+            {
+                if (isSuppressed(name))
+                    result.AllowListed.Add(Describe(name, allowReasonLookup(name)));
+                else
+                    result.Stale.Add(name);
+            }
+            return result;
+        }
+
+        private static string Describe(string name, string reason)
+            => string.IsNullOrEmpty(reason) ? name : $"{name} ({reason})";
+
+        // An attribute is not reported when it is an explicit allow-list entry, a dynamic prefix
+        // itself (ends with '-'), or a member of a dynamic prefix family (e.g. d-on-click).
+        private static bool IsSuppressedAttribute(string name, AllowList allow)
+        {
+            if (allow.Attributes.ContainsKey(name))
+                return true;
+            if (name.EndsWith("-", StringComparison.Ordinal))
+                return true;
+            foreach (string prefix in allow.AttributePrefixes)
+            {
+                if (name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+
+        private static void EnsureEngineParsed()
+        {
+            if (_engineFunctions != null)
+                return;
+            lock (EngineLock)
+            {
+                if (_engineFunctions != null)
+                    return;
+                Assembly engineAssembly = typeof(DrapoMiddlewareOptions).Assembly;
+                string js = ReadEngineJs(engineAssembly);
+                _engineFunctions = ExtractMatches(FunctionRegex, js);
+                _engineAttributes = ExtractMatches(AttributeRegex, js);
+                _engineVersion = ResolveEngineVersion(engineAssembly);
+            }
+        }
+
+        // The assembly version is a static 1.0.0.0; the package/file version (e.g. 2025.12.9.6)
+        // is the meaningful one, so prefer informational/file version.
+        private static string ResolveEngineVersion(Assembly engineAssembly)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(engineAssembly.Location))
+                {
+                    string fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(engineAssembly.Location).FileVersion;
+                    if (!string.IsNullOrWhiteSpace(fileVersion) && fileVersion != "1.0.0.0")
+                        return fileVersion;
+                }
+            }
+            catch
+            {
+                // fall through to attribute / assembly version
+            }
+            string informational = engineAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            if (!string.IsNullOrWhiteSpace(informational))
+                return informational;
+            return engineAssembly.GetName().Version?.ToString() ?? "unknown";
+        }
+
+        private static HashSet<string> ExtractMatches(Regex regex, string js)
+        {
+            return new HashSet<string>(
+                regex.Matches(js).Select(m => m.Groups[1].Value.ToLowerInvariant()));
+        }
+
+        private static string ReadEngineJs(Assembly engineAssembly)
+        {
+            string[] names = engineAssembly.GetManifestResourceNames();
+            // Prefer the unminified drapo.js (stable identifiers) over drapo.min.js.
+            string resource = names.FirstOrDefault(n => n.EndsWith("drapo.js", StringComparison.OrdinalIgnoreCase) && !n.EndsWith("min.js", StringComparison.OrdinalIgnoreCase))
+                              ?? names.FirstOrDefault(n => n.EndsWith("drapo.js", StringComparison.OrdinalIgnoreCase));
+            if (resource == null)
+                throw new InvalidOperationException("Could not find the embedded drapo.js engine resource in the Drapo assembly.");
+            using Stream stream = engineAssembly.GetManifestResourceStream(resource);
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
+        private async Task<AllowList> LoadAllowList()
+        {
+            string path = Path.Combine(_env.WebRootPath, "app", "catalog-allowlist.json");
+            if (!File.Exists(path))
+                return new AllowList();
+            string json = await File.ReadAllTextAsync(path);
+            return JsonConvert.DeserializeObject<AllowList>(json) ?? new AllowList();
+        }
+
+        /// <summary>Deserialized shape of catalog-allowlist.json.</summary>
+        private class AllowList
+        {
+            [JsonProperty("functions")]
+            public Dictionary<string, string> Functions { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            [JsonProperty("attributes")]
+            public Dictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            [JsonProperty("attributePrefixes")]
+            public List<string> AttributePrefixes { get; set; } = new List<string>();
+        }
+    }
+}

--- a/src/WebDocs/Services/ICatalogDriftService.cs
+++ b/src/WebDocs/Services/ICatalogDriftService.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using WebDocs.Models;
+
+namespace WebDocs.Services
+{
+    /// <summary>
+    /// Compares the documentation catalog (functions/attributes) against the Drapo engine
+    /// bundled inside the docs application, reporting undocumented and stale entries.
+    /// </summary>
+    public interface ICatalogDriftService
+    {
+        /// <summary>
+        /// Builds the drift report by extracting the function/attribute sets from the bundled
+        /// engine JS and diffing them against the documented sets, applying the allow-list.
+        /// </summary>
+        Task<CatalogDriftVM> GetDrift();
+    }
+}

--- a/src/WebDocs/Startup.cs
+++ b/src/WebDocs/Startup.cs
@@ -43,6 +43,7 @@ namespace WebDocs
             services.AddScoped<IAttributeService, AttributeService>();
             services.AddScoped<IDataTypeService, DataTypeService>();
             services.AddScoped<IConceptService, ConceptService>();
+            services.AddScoped<ICatalogDriftService, CatalogDriftService>();
             services.AddScoped<INuGetService, NuGetService>();
             services.AddScoped<MenuController, MenuController>();
             services.AddScoped<SearchController, SearchController>();

--- a/src/WebDocs/Tools/CatalogTool.cs
+++ b/src/WebDocs/Tools/CatalogTool.cs
@@ -1,0 +1,31 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using WebDocs.Models;
+using WebDocs.Services;
+
+namespace WebDocs.Tools
+{
+    /// <summary>
+    /// Tool exposing catalog-drift detection to the MCP server.
+    /// </summary>
+    [McpServerToolType]
+    public class CatalogTool
+    {
+        private readonly ICatalogDriftService _catalogDriftService;
+
+        public CatalogTool(ICatalogDriftService catalogDriftService)
+        {
+            this._catalogDriftService = catalogDriftService;
+        }
+
+        /// <summary>
+        /// Reports drift between the documentation catalog and the bundled Drapo engine.
+        /// </summary>
+        [McpServerTool(Name = "verify_catalog"), Description("Verify the Drapo documentation catalog against the engine bundled in this docs app. Returns functions/attributes that exist in the engine but are not documented (Undocumented), and documented entries missing from the engine (Stale). Function drift is authoritative; attribute drift is heuristic (string-literal based, curated by an allow-list). Use this to confirm the catalog the other tools serve is complete before relying on it.")]
+        public async Task<CatalogDriftVM> VerifyCatalog()
+        {
+            return (await this._catalogDriftService.GetDrift());
+        }
+    }
+}

--- a/src/WebDocs/wwwroot/app/catalog-allowlist.json
+++ b/src/WebDocs/wwwroot/app/catalog-allowlist.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Allow-list for the verify_catalog MCP drift tool. Entries here are intentionally NOT reported as drift. Functions/attributes map a name (lowercase) to the reason it is excluded. attributePrefixes are dynamic prefixes the engine expands at runtime (e.g. d-on-{event}), so the literal prefix is never a standalone documented attribute.",
+  "functions": {},
+  "attributes": {},
+  "attributePrefixes": [
+    "d-attr-",
+    "d-on-",
+    "d-propagation-",
+    "d-validation-on-",
+    "d-sector-container-",
+    "d-dataproperty-"
+  ]
+}


### PR DESCRIPTION
## What

Adds a `verify_catalog` MCP tool that detects drift between the documentation catalog and the Drapo engine. Addresses #285.

## How it stays self-contained

The docs app already references the **Drapo NuGet package** and serves the engine at `/drapo.js`. The tool extracts the authoritative function/attribute sets from the **embedded `drapo.js` resource** of the `Sysphera.Middleware.Drapo` assembly — the exact engine version the docs ship. No cross-repo access, no network, no submodule. When docs bumps the Drapo package, the check automatically tracks the new engine.

## Behaviour

- **Functions — authoritative.** Engine functions are dispatched by an exact comparison (`functionParsed.Name === '...'`), so the diff is exact: **95 engine vs 86 documented → 9 undocumented, 0 stale.**
  - Undocumented: `break, clearplumber, external, getexternalframe, getexternalframemessage, setexternalframe, setexternalframemessage, updatetokenantiforgery, wait`
- **Attributes — heuristic.** There is no central attribute dispatch in the engine; names are scraped from string literals (~103) and include many internal / dynamically-prefixed attributes. Curated via `catalog-allowlist.json` (explicit names + dynamic prefix families like `d-on-`, `d-attr-`, `d-propagation-`). `AttributesAreHeuristic = true` flags this in the output.
  - Notable real finding surfaced as **Stale**: the doc attribute typo **`d-datapollingtimepsan`** (engine has `d-datapollingtimespan`).

`HasDrift` reflects the authoritative function drift; attribute drift is informational.

## Files

- `Tools/CatalogTool.cs` — `verify_catalog` MCP tool
- `Services/CatalogDriftService.cs` (+ `ICatalogDriftService`) — engine extraction, diff, allow-list
- `Models/CatalogDriftVM.cs` — result shape (per-category Undocumented/Stale/AllowListed)
- `wwwroot/app/catalog-allowlist.json` — curated suppressions (seeded with dynamic prefixes)
- `Startup.cs` — DI registration

## Verification

- `dotnet build` succeeds (only pre-existing `FunctionController` warnings).
- Ran the **real** `CatalogDriftService` against the real docs + bundled engine: produced the 95/86/9 function result above and correctly moved dynamic-prefix attributes to `AllowListed` while surfacing the `d-datapollingtimepsan` typo as Stale.

## Notes / follow-ups (not in this PR)

- This is an **MCP tool**, not a CI gate (per the chosen approach). The docs CI is currently a Docker stub; wiring a fail-on-drift step can be a follow-up.
- The 9 undocumented functions still need triage (document vs allow-list) — separate content work tracked in #285. The 4 `*ExternalFrame*` ones correspond to existing issues #221/#225/#227/#231.
- `EngineVersion` reports the assembly informational version (`1.0.0+<commit-sha>`), which pins the exact engine build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
