### PR TITLE
i284: Add validate_drapo MCP tool

### DIFF
--- a/src/WebDocs/Models/DrapoDiagnosticVM.cs
+++ b/src/WebDocs/Models/DrapoDiagnosticVM.cs
@@ -1,0 +1,19 @@
+namespace WebDocs.Models
+{
+    /// <summary>
+    /// A single problem found by validate_drapo in a Drapo template.
+    /// </summary>
+    public class DrapoDiagnosticVM
+    {
+        /// <summary>Severity: "error" (definitely wrong) or "warning" (likely wrong).</summary>
+        public string Level { get; set; }
+        /// <summary>Stable rule id, e.g. unknown-attribute, unknown-function, wrong-arity, malformed-dfor, unbalanced-mustache.</summary>
+        public string Rule { get; set; }
+        /// <summary>Human-readable explanation.</summary>
+        public string Message { get; set; }
+        /// <summary>1-based line of the offending token.</summary>
+        public int Line { get; set; }
+        /// <summary>1-based column of the offending token.</summary>
+        public int Column { get; set; }
+    }
+}

--- a/src/WebDocs/Models/DrapoValidationResultVM.cs
+++ b/src/WebDocs/Models/DrapoValidationResultVM.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace WebDocs.Models
+{
+    /// <summary>
+    /// Result of validate_drapo: whether the template is valid and the diagnostics found.
+    /// </summary>
+    public class DrapoValidationResultVM
+    {
+        /// <summary>True when there are no error-level diagnostics (warnings may still be present).</summary>
+        public bool Valid { get; set; }
+        /// <summary>Number of error-level diagnostics.</summary>
+        public int ErrorCount { get; set; }
+        /// <summary>Number of warning-level diagnostics.</summary>
+        public int WarningCount { get; set; }
+        /// <summary>Version of the bundled engine the template was validated against.</summary>
+        public string EngineVersion { get; set; }
+        /// <summary>The diagnostics, in document order.</summary>
+        public List<DrapoDiagnosticVM> Diagnostics { get; set; } = new List<DrapoDiagnosticVM>();
+    }
+}

--- a/src/WebDocs/Services/DrapoEngineCatalog.cs
+++ b/src/WebDocs/Services/DrapoEngineCatalog.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Sysphera.Middleware.Drapo;
+
+namespace WebDocs.Services
+{
+    /// <summary>
+    /// Reads the engine bundled in the Sysphera.Middleware.Drapo assembly (the embedded drapo.js,
+    /// the same script served at /drapo.js) and exposes its function/attribute sets. The engine is
+    /// fixed for the process lifetime, so it is parsed once and cached.
+    /// </summary>
+    public class DrapoEngineCatalog : IDrapoEngineCatalog
+    {
+        // Function dispatch in the engine is an exact comparison: functionParsed.Name === 'name'.
+        private static readonly Regex FunctionRegex = new Regex(@"functionParsed\.Name\s*===\s*['""]([a-z0-9_]+)['""]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        // Attributes appear only as string literals (no central dispatch).
+        private static readonly Regex AttributeRegex = new Regex(@"['""](d-[a-z][a-z-]*)['""]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly object Lock = new object();
+        private static HashSet<string> _functions;
+        private static HashSet<string> _attributes;
+        private static List<string> _attributePrefixes;
+        private static string _version;
+
+        public string EngineVersion
+        {
+            get { EnsureParsed(); return _version; }
+        }
+
+        public bool IsValidFunction(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return false;
+            EnsureParsed();
+            return _functions.Contains(name.ToLowerInvariant());
+        }
+
+        public bool IsValidAttribute(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return false;
+            EnsureParsed();
+            string lower = name.ToLowerInvariant();
+            if (_attributes.Contains(lower))
+                return true;
+            // Dynamic prefix families: engine ships the prefix literal (ends with '-'),
+            // e.g. d-on- -> d-on-click, d-attr- -> d-attr-href, d-dataproperty- -> d-dataproperty-x.
+            foreach (string prefix in _attributePrefixes)
+            {
+                if (lower.StartsWith(prefix, StringComparison.Ordinal) && lower.Length > prefix.Length)
+                    return true;
+            }
+            return false;
+        }
+
+        private static void EnsureParsed()
+        {
+            if (_functions != null)
+                return;
+            lock (Lock)
+            {
+                if (_functions != null)
+                    return;
+                Assembly engine = typeof(DrapoMiddlewareOptions).Assembly;
+                string js = ReadEngineJs(engine);
+                _functions = new HashSet<string>(FunctionRegex.Matches(js).Select(m => m.Groups[1].Value.ToLowerInvariant()));
+                _attributes = new HashSet<string>(AttributeRegex.Matches(js).Select(m => m.Groups[1].Value.ToLowerInvariant()));
+                _attributePrefixes = _attributes.Where(a => a.EndsWith("-", StringComparison.Ordinal)).ToList();
+                _version = ResolveVersion(engine);
+            }
+        }
+
+        private static string ReadEngineJs(Assembly engine)
+        {
+            string[] names = engine.GetManifestResourceNames();
+            string resource = names.FirstOrDefault(n => n.EndsWith("drapo.js", StringComparison.OrdinalIgnoreCase) && !n.EndsWith("min.js", StringComparison.OrdinalIgnoreCase))
+                              ?? names.FirstOrDefault(n => n.EndsWith("drapo.js", StringComparison.OrdinalIgnoreCase));
+            if (resource == null)
+                throw new InvalidOperationException("Could not find the embedded drapo.js engine resource in the Drapo assembly.");
+            using Stream stream = engine.GetManifestResourceStream(resource);
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
+        private static string ResolveVersion(Assembly engine)
+        {
+            string informational = engine.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            if (!string.IsNullOrWhiteSpace(informational))
+                return informational;
+            return engine.GetName().Version?.ToString() ?? "unknown";
+        }
+    }
+}

--- a/src/WebDocs/Services/DrapoValidatorService.cs
+++ b/src/WebDocs/Services/DrapoValidatorService.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using WebDocs.Models;
+
+namespace WebDocs.Services
+{
+    /// <summary>
+    /// Validates Drapo templates against the bundled engine (for attribute/function existence)
+    /// and the documentation catalog (for function arity). See <see cref="IDrapoValidatorService"/>.
+    /// </summary>
+    public class DrapoValidatorService : IDrapoValidatorService
+    {
+        private readonly IDrapoEngineCatalog _engine;
+        private readonly IFunctionService _functions;
+
+        // d-name="value" or d-name='value' preceded by whitespace (i.e. inside a tag). Only
+        // valued attributes are checked, to avoid matching attribute names mentioned in prose.
+        private static readonly Regex AttributeRegex = new Regex(
+            @"(?<=\s)(d-[A-Za-z][\w-]*)\s*=\s*(?:""([^""]*)""|'([^']*)')",
+            RegexOptions.Compiled);
+        private static readonly Regex DForRegex = new Regex(@"^\s*[A-Za-z_]\w*\s+in\s+\S+\s*$", RegexOptions.Compiled);
+        private static readonly Regex FunctionCallRegex = new Regex(@"([A-Za-z_]\w*)\s*\(", RegexOptions.Compiled);
+
+        public DrapoValidatorService(IDrapoEngineCatalog engine, IFunctionService functions)
+        {
+            _engine = engine;
+            _functions = functions;
+        }
+
+        public async Task<DrapoValidationResultVM> Validate(string html)
+        {
+            var diagnostics = new List<DrapoDiagnosticVM>();
+            if (!string.IsNullOrEmpty(html))
+            {
+                CheckMustaches(html, diagnostics);
+                await CheckAttributesAndFunctions(html, diagnostics);
+            }
+
+            var ordered = diagnostics.OrderBy(d => d.Line).ThenBy(d => d.Column).ToList();
+            return new DrapoValidationResultVM
+            {
+                EngineVersion = _engine.EngineVersion,
+                Diagnostics = ordered,
+                ErrorCount = ordered.Count(d => d.Level == "error"),
+                WarningCount = ordered.Count(d => d.Level == "warning"),
+                Valid = !ordered.Any(d => d.Level == "error")
+            };
+        }
+
+        private async Task CheckAttributesAndFunctions(string html, List<DrapoDiagnosticVM> diagnostics)
+        {
+            // Resolve documented function names once for case-insensitive arity lookup.
+            var docFunctionNames = (await _functions.GetNames())
+                .ToDictionary(n => n.ToLowerInvariant(), n => n);
+            var parameterCache = new Dictionary<string, List<FunctionParameterVM>>();
+
+            foreach (Match match in AttributeRegex.Matches(html))
+            {
+                string attribute = match.Groups[1].Value;
+                string lower = attribute.ToLowerInvariant();
+                Group valueGroup = match.Groups[2].Success ? match.Groups[2] : match.Groups[3];
+                string value = valueGroup.Value;
+
+                if (!_engine.IsValidAttribute(attribute))
+                {
+                    Add(diagnostics, html, match.Groups[1].Index, "error", "unknown-attribute",
+                        $"Unknown Drapo attribute '{attribute}'. It is not defined in the engine.");
+                    // Even if the attribute is unknown, still inspect its value below where useful.
+                }
+
+                if (lower == "d-for")
+                {
+                    if (!DForRegex.IsMatch(value))
+                        Add(diagnostics, html, valueGroup.Index, "error", "malformed-dfor",
+                            $"Malformed d-for: '{value.Trim()}'. Expected the form '{{item}} in {{iterator}}'.");
+                }
+
+                if (lower.StartsWith("d-on-", StringComparison.Ordinal))
+                {
+                    foreach (var call in ScanFunctionCalls(value))
+                    {
+                        int index = valueGroup.Index + call.NameIndex;
+                        if (!_engine.IsValidFunction(call.Name))
+                        {
+                            Add(diagnostics, html, index, "error", "unknown-function",
+                                $"Unknown Drapo function '{call.Name}'. It is not dispatched by the engine.");
+                            continue;
+                        }
+                        await CheckArity(call, index, docFunctionNames, parameterCache, html, diagnostics);
+                    }
+                }
+            }
+        }
+
+        private async Task CheckArity(
+            FunctionCall call, int index,
+            Dictionary<string, string> docFunctionNames,
+            Dictionary<string, List<FunctionParameterVM>> parameterCache,
+            string html, List<DrapoDiagnosticVM> diagnostics)
+        {
+            string key = call.Name.ToLowerInvariant();
+            if (!docFunctionNames.TryGetValue(key, out string docName))
+                return; // not documented -> no signature to check against
+
+            if (!parameterCache.TryGetValue(key, out var parameters))
+            {
+                FunctionVM vm = await _functions.Get(docName);
+                parameters = vm?.Parameters ?? new List<FunctionParameterVM>();
+                parameterCache[key] = parameters;
+            }
+
+            int required = parameters.Count(p => !p.Optional);
+            int provided = SplitArguments(call.Arguments).Count;
+            // Only flag too-few arguments: many Drapo functions are variadic (e.g. CreateData),
+            // so an upper bound would produce false positives.
+            if (provided < required)
+            {
+                Add(diagnostics, html, index, "warning", "wrong-arity",
+                    $"Function '{docName}' expects at least {required} argument(s) but got {provided}.");
+            }
+        }
+
+        // Scans a handler expression for function calls, returning each name, its position, and
+        // its raw argument text. Nested calls are returned too (each is validated independently).
+        private static IEnumerable<FunctionCall> ScanFunctionCalls(string value)
+        {
+            foreach (Match m in FunctionCallRegex.Matches(value))
+            {
+                int parenIndex = m.Index + m.Length - 1;
+                int depth = 0;
+                int close = -1;
+                for (int i = parenIndex; i < value.Length; i++)
+                {
+                    if (value[i] == '(') depth++;
+                    else if (value[i] == ')') { depth--; if (depth == 0) { close = i; break; } }
+                }
+                string args = close > parenIndex ? value.Substring(parenIndex + 1, close - parenIndex - 1) : value.Substring(parenIndex + 1);
+                yield return new FunctionCall
+                {
+                    Name = m.Groups[1].Value,
+                    NameIndex = m.Groups[1].Index,
+                    Arguments = args
+                };
+            }
+        }
+
+        // Splits a function argument string at top-level commas, ignoring commas nested inside
+        // parentheses or mustache expressions.
+        private static List<string> SplitArguments(string args)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrWhiteSpace(args))
+                return result;
+            int depth = 0;
+            int mustache = 0;
+            int start = 0;
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (i + 1 < args.Length && args[i] == '{' && args[i + 1] == '{') { mustache++; i++; continue; }
+                if (i + 1 < args.Length && args[i] == '}' && args[i + 1] == '}') { if (mustache > 0) mustache--; i++; continue; }
+                if (mustache > 0) continue;
+                char c = args[i];
+                if (c == '(') depth++;
+                else if (c == ')') { if (depth > 0) depth--; }
+                else if (c == ',' && depth == 0)
+                {
+                    result.Add(args.Substring(start, i - start));
+                    start = i + 1;
+                }
+            }
+            result.Add(args.Substring(start));
+            return result;
+        }
+
+        private static void CheckMustaches(string html, List<DrapoDiagnosticVM> diagnostics)
+        {
+            var openStack = new Stack<int>();
+            for (int i = 0; i + 1 < html.Length; i++)
+            {
+                if (html[i] == '{' && html[i + 1] == '{')
+                {
+                    openStack.Push(i);
+                    i++;
+                }
+                else if (html[i] == '}' && html[i + 1] == '}')
+                {
+                    if (openStack.Count == 0)
+                        Add(diagnostics, html, i, "error", "unbalanced-mustache", "Unexpected '}}' without a matching '{{'.");
+                    else
+                        openStack.Pop();
+                    i++;
+                }
+            }
+            foreach (int index in openStack)
+                Add(diagnostics, html, index, "error", "unbalanced-mustache", "Unclosed '{{' without a matching '}}'.");
+        }
+
+        private static void Add(List<DrapoDiagnosticVM> diagnostics, string html, int index, string level, string rule, string message)
+        {
+            (int line, int column) = Position(html, index);
+            diagnostics.Add(new DrapoDiagnosticVM { Level = level, Rule = rule, Message = message, Line = line, Column = column });
+        }
+
+        private static (int line, int column) Position(string text, int index)
+        {
+            int line = 1, column = 1;
+            int max = Math.Min(index, text.Length);
+            for (int i = 0; i < max; i++)
+            {
+                if (text[i] == '\n') { line++; column = 1; }
+                else column++;
+            }
+            return (line, column);
+        }
+
+        private class FunctionCall
+        {
+            public string Name { get; set; }
+            public int NameIndex { get; set; }
+            public string Arguments { get; set; }
+        }
+    }
+}

--- a/src/WebDocs/Services/IDrapoEngineCatalog.cs
+++ b/src/WebDocs/Services/IDrapoEngineCatalog.cs
@@ -1,0 +1,22 @@
+namespace WebDocs.Services
+{
+    /// <summary>
+    /// The authoritative set of functions and attributes supported by the Drapo engine that is
+    /// bundled inside this docs app (read from the embedded drapo.js). Used to validate templates
+    /// without depending on the (possibly incomplete) documentation catalog.
+    /// </summary>
+    public interface IDrapoEngineCatalog
+    {
+        /// <summary>True if <paramref name="name"/> is a function dispatched by the engine (case-insensitive).</summary>
+        bool IsValidFunction(string name);
+
+        /// <summary>
+        /// True if <paramref name="name"/> is a supported attribute (case-insensitive): an exact
+        /// engine attribute, or a member of a dynamic prefix family such as d-on-{event}.
+        /// </summary>
+        bool IsValidAttribute(string name);
+
+        /// <summary>Version identifier of the bundled engine.</summary>
+        string EngineVersion { get; }
+    }
+}

--- a/src/WebDocs/Services/IDrapoValidatorService.cs
+++ b/src/WebDocs/Services/IDrapoValidatorService.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using WebDocs.Models;
+
+namespace WebDocs.Services
+{
+    /// <summary>
+    /// Validates a Drapo template (HTML snippet or full file) and reports diagnostics:
+    /// unknown attributes/functions, wrong arity, malformed d-for, unbalanced mustaches.
+    /// </summary>
+    public interface IDrapoValidatorService
+    {
+        Task<DrapoValidationResultVM> Validate(string html);
+    }
+}

--- a/src/WebDocs/Startup.cs
+++ b/src/WebDocs/Startup.cs
@@ -43,6 +43,8 @@ namespace WebDocs
             services.AddScoped<IAttributeService, AttributeService>();
             services.AddScoped<IDataTypeService, DataTypeService>();
             services.AddScoped<IConceptService, ConceptService>();
+            services.AddSingleton<IDrapoEngineCatalog, DrapoEngineCatalog>();
+            services.AddScoped<IDrapoValidatorService, DrapoValidatorService>();
             services.AddScoped<INuGetService, NuGetService>();
             services.AddScoped<MenuController, MenuController>();
             services.AddScoped<SearchController, SearchController>();

--- a/src/WebDocs/Tools/ValidationTool.cs
+++ b/src/WebDocs/Tools/ValidationTool.cs
@@ -1,0 +1,31 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using WebDocs.Models;
+using WebDocs.Services;
+
+namespace WebDocs.Tools
+{
+    /// <summary>
+    /// Tool exposing Drapo template validation to the MCP server.
+    /// </summary>
+    [McpServerToolType]
+    public class ValidationTool
+    {
+        private readonly IDrapoValidatorService _validatorService;
+
+        public ValidationTool(IDrapoValidatorService validatorService)
+        {
+            this._validatorService = validatorService;
+        }
+
+        /// <summary>
+        /// Validates a Drapo template and returns diagnostics.
+        /// </summary>
+        [McpServerTool(Name = "validate_drapo"), Description("Validate a Drapo template (HTML snippet or full file content). Pass the markup as 'html' and get back diagnostics for: unknown d-* attributes, unknown functions used in d-on-* handlers, functions called with too few arguments, malformed d-for syntax, and unbalanced {{ }} mustaches. Attribute/function existence is checked against the bundled Drapo engine; argument counts against the documented signatures. Use after writing or editing Drapo markup to confirm it is correct.")]
+        public async Task<DrapoValidationResultVM> ValidateDrapo(string html)
+        {
+            return (await this._validatorService.Validate(html));
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a `validate_drapo` MCP tool: pass a Drapo template (HTML snippet or full file) as `html`, get back diagnostics. Closes #284.

## Rules (v1)

| Rule | Level | Detects |
|------|-------|---------|
| `unknown-attribute` | error | a `d-*` attribute the engine doesn't define |
| `unknown-function` | error | a function used in a `d-on-*` handler that the engine doesn't dispatch |
| `wrong-arity` | warning | a documented function called with too few arguments |
| `malformed-dfor` | error | `d-for` not of the form `{item} in {iterator}` |
| `unbalanced-mustache` | error | unmatched `{{` / `}}` |

Each diagnostic carries `level`, `rule`, `message`, `line`, `column`. The result has `Valid` (no errors), `ErrorCount`, `WarningCount`, `EngineVersion`.

## Design note (deviation from the issue text, on purpose)

The issue suggested deriving the valid sets from the **docs catalog**. But that catalog is currently incomplete (we just filed 58 issues for undocumented functions/attributes). Validating against it would **falsely flag valid code** (e.g. `External()`, `d-template`). So:

- **Existence** (attributes + functions) is validated against the **bundled engine** — `DrapoEngineCatalog` reads the embedded `drapo.js` from the `Sysphera.Middleware.Drapo` assembly. Authoritative and complete; tracks the engine version docs ship.
- **Arity** is checked against the documented `parameters.json` signatures (only when the function is documented). Too-few only — many Drapo functions are variadic, so an upper bound would false-positive.

Attribute validation understands dynamic prefix families (`d-on-{event}`, `d-attr-*`, `d-dataProperty-*`, …) via the engine's prefix literals.

## Files

- `Tools/ValidationTool.cs` — `validate_drapo` MCP tool
- `Services/DrapoValidatorService.cs` (+ interface) — parsing + diagnostics
- `Services/DrapoEngineCatalog.cs` (+ interface) — engine function/attribute sets from `drapo.js`
- `Models/DrapoDiagnosticVM.cs`, `Models/DrapoValidationResultVM.cs`
- `Startup.cs` — DI registration

## Verification

`dotnet build` clean. Ran the real services against three templates:

- **Good** template → `Valid=true`, 0 diagnostics.
- **Bad** template → caught all five: `d-modl` (unknown-attribute), `item data` (malformed-dfor), `UpdateSectr` (unknown-function), `UpdateSector()` (wrong-arity warning, expects ≥2), `{{item.Name}` (unbalanced-mustache).
- **Undocumented-but-valid** (`External()`, `d-template`) → `Valid=true`, no false positives.

## Known limitations (candidate follow-ups)

- Function detection runs on `d-on-*` handlers only (not `d-dataValue`/other expression attributes).
- Only valued attributes (`d-x="..."`) are checked, to avoid matching attribute names in prose; valueless attributes (e.g. `d-pre`) aren't checked.
- Arity is too-few only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
