### PR TITLE
Add drapo plugin marketplace + drapo-resolver plugin + discovery concept

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "drapo",
+  "owner": {
+    "name": "Drapo"
+  },
+  "description": "Drapo skills and tooling for AI agents (Claude Code / Copilot CLI).",
+  "plugins": [
+    {
+      "name": "drapo-resolver",
+      "source": "./plugins/drapo-resolver",
+      "description": "Project-aware Drapo symbol resolver: resolve data keys / components / sectors, find references, and scan for dangling references in any Drapo app.",
+      "category": "drapo",
+      "keywords": ["drapo", "resolver", "frontend", "go-to-definition"]
+    }
+  ]
+}

--- a/plugins/drapo-resolver/.claude-plugin/plugin.json
+++ b/plugins/drapo-resolver/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "drapo-resolver",
+  "description": "Project-aware Drapo symbol resolver: resolve data keys / components / sectors, find references, and scan for dangling references in any Drapo app.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Drapo"
+  },
+  "homepage": "https://github.com/spadrapo/docs",
+  "license": "MIT",
+  "keywords": ["drapo", "resolver", "frontend"]
+}

--- a/plugins/drapo-resolver/SKILL.md
+++ b/plugins/drapo-resolver/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: drapo-resolver
+description: Project-aware resolver for any Drapo application. Answers go-to-definition / find-references for app-specific Drapo symbols — d-dataKeys, components, and sectors — and scans for dangling references. Use before trusting that a binding key, component tag, or sector name actually exists in this app (the shared Drapo MCP only knows the framework, not your app's symbols).
+license: MIT
+---
+
+# Drapo Resolver Skill
+
+A **generic** Drapo skill: it indexes any Drapo app's frontend (`wwwroot/app` + `wwwroot/components`) and answers structured questions the shared Drapo docs MCP cannot — *which* `d-dataKey`s / components / sectors **this app** actually defined, and where they are used.
+
+> Distributed as a Claude Code plugin from the **`drapo` marketplace** (`spadrapo/docs`). Install with `/plugin marketplace add spadrapo/docs` then `/plugin install drapo-resolver@drapo`.
+
+## Drapo know-how bundled with this skill
+
+Beyond the resolver commands, this skill ships agnostic Drapo guidance — read the relevant file when working on Drapo:
+
+- **[`reference/using-drapo-correctly.md`](reference/using-drapo-correctly.md)** — how to write Drapo that works: storage & data loading, data binding, rendering (`d-for`/`d-if`), sectors & navigation, components, events, validation/formatting/live data, and do/don't rules. Read it **before writing or editing Drapo markup**.
+- **[`reference/troubleshooting.md`](reference/troubleshooting.md)** — a symptom → cause → confirm → fix playbook (binding shows literal `{{}}`, data not loading, `d-for` empty, component/sector not rendering, handler does nothing, …), built around inspecting the running app (`window.drapo.Introspection.GetSnapshot()`), the resolver, and `validate_drapo`. Read it **when something doesn't work**.
+
+These complement the live Drapo MCP (the exhaustive framework reference); see the division-of-labor table below.
+
+## When to use this skill
+
+- Before binding to a `d-dataKey`, using a `<d-component>`, or targeting a `d-sector` you didn't just author — confirm it exists (catches plausible-but-wrong guesses).
+- After editing Drapo HTML — run `scan-unresolved` to catch component tags that point at no component.
+- Renaming/refactoring a data key — use `find-references` to find every binding site first.
+
+## Recommended workflow
+
+Treat this skill as a correctness gate around any Drapo edit:
+
+1. **Before binding** — `resolve-datakey <key>` / `resolve-component <tag>` / `resolve-sector <name>`. If it returns `found:false`, you're about to bind to something that doesn't exist — define it or fix the name instead of guessing.
+2. **After editing markup** — run `scan-unresolved`; every `unresolvedComponents` entry is a real dangling tag to fix. Review `unresolvedSectorCandidates`.
+3. **Before renaming a key/sector** — `find-references` first, then update every site it lists.
+4. **Don't claim an edit is correct** until the symbols you used resolve and `scan-unresolved` is clean.
+
+## Works with the Drapo MCP (division of labor)
+
+This skill and the shared Drapo MCP are complementary — the **MCP knows the framework, this skill knows your app**. Use both:
+
+| Question | Use |
+|----------|-----|
+| Does this `d-*` attribute / function exist? What parameters does it take? | Drapo MCP — `get_attributes`, `get_functions`, `get_*_details` |
+| Is this snippet's Drapo syntax valid (unknown attrs/functions, arity, `d-for`, mustaches)? | Drapo MCP — `validate_drapo` |
+| How does a Drapo concept work (sectors, data binding, pipes, routing…)? | Drapo MCP — `get_concepts` / `get_concept_details` |
+| Does **this app's** `d-dataKey` / component / sector exist, and where? | **This skill** — `resolve-*` |
+| Everywhere a key is bound (for a safe rename) | **This skill** — `find-references` |
+
+Pair `validate_drapo` (*is the syntax legal?*) with `resolve-*` (*do the names I used actually exist in this app?*) for a complete check before finishing a Drapo edit.
+
+## Usage
+
+Run the bundled script with PowerShell. When installed as a plugin, it lives at `${CLAUDE_PLUGIN_ROOT}`:
+
+```
+pwsh "${CLAUDE_PLUGIN_ROOT}/drapo-resolver.ps1" <command> [name] [-Root <wwwroot>]
+```
+
+(If you're running a local copy instead, point `pwsh` at wherever `drapo-resolver.ps1` lives.)
+
+`-Root` is optional: if omitted, the script auto-detects the Drapo `wwwroot` (a `wwwroot` folder containing `app/`) under the current directory. Pass it explicitly if the repo has more than one. All output is JSON.
+
+### Commands
+
+| Command | Example | Returns |
+|---------|---------|---------|
+| `resolve-datakey <key>` | `resolve-datakey myDataKey` | declaration site(s): `file`, `line`, `dataType`, `dataUrlGet`, `dataUrlSet`, `dataValue`. `found:false` if undefined. |
+| `resolve-component <tag>` | `resolve-component d-mycomponent` | the component `folder` and its `files`, or `found:false`. Accepts `d-foo` or `foo`. |
+| `resolve-sector <name>` | `resolve-sector myContentSector` | declaration site(s) of the `d-sector`. |
+| `find-references <key>` | `find-references myDataKey` | every `declaration` (`d-dataKey=`) and `reference` (mustache / `d-*` attribute) site, with `file`/`line`/`text`. |
+| `scan-unresolved` | `scan-unresolved` | `unresolvedComponents` (high-confidence: a `<d-x>` tag with no `wwwroot/components/x` folder) and `unresolvedSectorCandidates` (`UpdateSector()` targets with no static `d-sector` declaration — review, not errors). |
+
+### Examples
+
+```bash
+# Does this data key exist, and what is it?
+pwsh "${CLAUDE_PLUGIN_ROOT}/drapo-resolver.ps1" resolve-datakey myDataKey
+
+# Where is a component defined?
+pwsh "${CLAUDE_PLUGIN_ROOT}/drapo-resolver.ps1" resolve-component d-mycomponent
+
+# Find everything that binds a key before renaming it.
+pwsh "${CLAUDE_PLUGIN_ROOT}/drapo-resolver.ps1" find-references myDataKey
+
+# Catch component tags that point at no component.
+pwsh "${CLAUDE_PLUGIN_ROOT}/drapo-resolver.ps1" scan-unresolved
+```
+
+## Notes & limitations
+
+- **Components** resolve to `wwwroot/components/<name>` (tag `d-<name>`). An app that registers components from additional paths may produce `unresolvedComponents` that are actually valid — treat them as candidates to verify.
+- **Sectors and data keys** can be declared in dynamically loaded or parent content, so `unresolvedSectorCandidates` is intentionally a *candidate* list, not an error list. Use `resolve-*` / `find-references` to check a specific symbol with confidence.
+- **Routes**: Drapo apps that navigate via `UpdateSector` (rather than client `CreateRoute`) have no separate route table to resolve; sector resolution covers those targets.
+- Parsing is convention-based (regex over `d-*` attributes), consistent with the docs-side `validate_drapo` tool.

--- a/plugins/drapo-resolver/drapo-resolver.ps1
+++ b/plugins/drapo-resolver/drapo-resolver.ps1
@@ -1,0 +1,192 @@
+<#
+.SYNOPSIS
+    Project-aware Drapo resolver for any Drapo application: go-to-definition /
+    find-references for app-specific Drapo symbols (data keys, components, sectors).
+
+.DESCRIPTION
+    Indexes a Drapo app's frontend (wwwroot/app + wwwroot/components) and answers
+    structured (JSON) queries the shared docs MCP cannot: which d-dataKeys / components /
+    sectors THIS app actually defined, and where they are referenced. Use it to confirm a
+    binding target exists before claiming an edit is correct (catches plausible-but-wrong
+    guesses).
+
+.PARAMETER Command
+    resolve-datakey | resolve-component | resolve-sector | find-references | scan-unresolved
+
+.PARAMETER Name
+    The symbol to resolve (data key, component tag/name, sector name). Omitted for scan-unresolved.
+
+.PARAMETER Root
+    wwwroot path. If omitted, auto-detected (a 'wwwroot' folder containing 'app/') under the
+    current directory.
+
+.EXAMPLE
+    pwsh ./drapo-resolver.ps1 resolve-datakey myDataKey
+    pwsh ./drapo-resolver.ps1 resolve-component d-mycomponent
+    pwsh ./drapo-resolver.ps1 find-references myDataKey
+    pwsh ./drapo-resolver.ps1 scan-unresolved
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateSet('resolve-datakey', 'resolve-component', 'resolve-sector', 'find-references', 'scan-unresolved')]
+    [string]$Command,
+
+    [Parameter(Position = 1)]
+    [string]$Name,
+
+    [string]$Root
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Find-DrapoRoot {
+    # A Drapo wwwroot is a directory named 'wwwroot' that contains an 'app' folder
+    # (and usually 'components'). Search under the current directory, skipping build output.
+    $candidates = Get-ChildItem -Path (Get-Location) -Recurse -Directory -Filter 'wwwroot' -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '[\\/](bin|obj|node_modules)[\\/]' } |
+        Where-Object { Test-Path (Join-Path $_.FullName 'app') }
+    if ($candidates.Count -eq 1) { return $candidates[0].FullName }
+    if ($candidates.Count -gt 1) {
+        throw "Multiple Drapo wwwroot folders found; pass -Root explicitly:`n" + (($candidates.FullName) -join "`n")
+    }
+    throw "Could not locate a Drapo wwwroot (a 'wwwroot' folder containing 'app') under '$(Get-Location)'. Pass -Root explicitly."
+}
+
+if (-not $Root) { $Root = Find-DrapoRoot }
+$Root = (Resolve-Path $Root).Path
+$AppDir = Join-Path $Root 'app'
+$ComponentsDir = Join-Path $Root 'components'
+
+$TagRegex = [regex]'(?s)<[a-zA-Z][^>]*?>'
+
+function Get-AppFiles { Get-ChildItem -Path $AppDir -Recurse -Filter *.html -File }
+function Get-RelPath([string]$p) { ($p.Substring($Root.Length).TrimStart('\', '/')) -replace '\\', '/' }
+function Get-LineNumber([string]$content, [int]$index) { (($content.Substring(0, $index)) -split "`n").Length }
+function Get-AttrValue([string]$tag, [string]$attr) {
+    $m = [regex]::Match($tag, '(?i)\b' + [regex]::Escape($attr) + '\s*=\s*"([^"]*)"')
+    if ($m.Success) { return $m.Groups[1].Value } else { return $null }
+}
+function Get-ComponentFolders { (Get-ChildItem -Path $ComponentsDir -Directory).Name }
+function Write-Result($obj) { $obj | ConvertTo-Json -Depth 8 }
+
+function Invoke-ResolveDataKey([string]$key) {
+    $decls = [System.Collections.Generic.List[object]]::new()
+    foreach ($f in Get-AppFiles) {
+        $c = Get-Content -Raw -LiteralPath $f.FullName
+        foreach ($m in $TagRegex.Matches($c)) {
+            $tag = $m.Value
+            if ((Get-AttrValue $tag 'd-dataKey') -eq $key) {
+                $decls.Add([pscustomobject]@{
+                        file       = Get-RelPath $f.FullName
+                        line       = Get-LineNumber $c $m.Index
+                        dataType   = Get-AttrValue $tag 'd-dataType'
+                        dataUrlGet = Get-AttrValue $tag 'd-dataUrlGet'
+                        dataUrlSet = Get-AttrValue $tag 'd-dataUrlSet'
+                        dataValue  = Get-AttrValue $tag 'd-dataValue'
+                    })
+            }
+        }
+    }
+    Write-Result ([pscustomobject]@{ command = 'resolve-datakey'; query = $key; found = ($decls.Count -gt 0); declarations = @($decls) })
+}
+
+function Invoke-ResolveSector([string]$name) {
+    $decls = [System.Collections.Generic.List[object]]::new()
+    foreach ($f in Get-AppFiles) {
+        $c = Get-Content -Raw -LiteralPath $f.FullName
+        foreach ($m in $TagRegex.Matches($c)) {
+            if ((Get-AttrValue $m.Value 'd-sector') -eq $name) {
+                $decls.Add([pscustomobject]@{ file = Get-RelPath $f.FullName; line = Get-LineNumber $c $m.Index })
+            }
+        }
+    }
+    Write-Result ([pscustomobject]@{ command = 'resolve-sector'; query = $name; found = ($decls.Count -gt 0); declarations = @($decls) })
+}
+
+function Invoke-ResolveComponent([string]$tag) {
+    $folder = ($tag -replace '^d-', '').ToLowerInvariant()
+    $path = Join-Path $ComponentsDir $folder
+    if (Test-Path -LiteralPath $path -PathType Container) {
+        $files = (Get-ChildItem -LiteralPath $path -File | ForEach-Object { Get-RelPath $_.FullName })
+        Write-Result ([pscustomobject]@{ command = 'resolve-component'; query = $tag; found = $true; component = $folder; folder = (Get-RelPath $path); files = @($files) })
+    }
+    else {
+        Write-Result ([pscustomobject]@{ command = 'resolve-component'; query = $tag; found = $false; component = $folder })
+    }
+}
+
+function Invoke-FindReferences([string]$key) {
+    $esc = [regex]::Escape($key)
+    $declRx = [regex]('(?i)d-dataKey\s*=\s*"' + $esc + '"')
+    # The key used in a mustache, or as a value token inside any d-* attribute.
+    $refRx = [regex]('(\{\{\s*' + $esc + '\b)|(?i)\bd-[a-z][\w-]*\s*=\s*"[^"]*\b' + $esc + '\b[^"]*"')
+    $declarations = [System.Collections.Generic.List[object]]::new()
+    $references = [System.Collections.Generic.List[object]]::new()
+    foreach ($f in Get-AppFiles) {
+        $rel = Get-RelPath $f.FullName
+        $ln = 0
+        foreach ($line in (Get-Content -LiteralPath $f.FullName)) {
+            $ln++
+            if ($declRx.IsMatch($line)) {
+                $declarations.Add([pscustomobject]@{ file = $rel; line = $ln; text = $line.Trim() })
+            }
+            elseif ($refRx.IsMatch($line)) {
+                $references.Add([pscustomobject]@{ file = $rel; line = $ln; text = $line.Trim() })
+            }
+        }
+    }
+    Write-Result ([pscustomobject]@{ command = 'find-references'; query = $key; declarationCount = $declarations.Count; referenceCount = $references.Count; declarations = @($declarations); references = @($references) })
+}
+
+function Invoke-ScanUnresolved {
+    $componentSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($c in Get-ComponentFolders) { [void]$componentSet.Add($c) }
+    $declaredSectors = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+
+    $compTagRx = [regex]'(?i)<d-([a-z0-9]+)'
+    $sectorDeclRx = [regex]'(?i)d-sector\s*=\s*"([^"]+)"'
+    $updateSectorRx = [regex]'(?i)UpdateSector\(\s*([A-Za-z0-9_]+)'
+
+    $unresolvedComponents = [System.Collections.Generic.List[object]]::new()
+    $sectorUsages = [System.Collections.Generic.List[object]]::new()
+
+    # First pass: collect declared sectors.
+    foreach ($f in Get-AppFiles) {
+        $c = Get-Content -Raw -LiteralPath $f.FullName
+        foreach ($m in $sectorDeclRx.Matches($c)) { [void]$declaredSectors.Add($m.Groups[1].Value) }
+    }
+
+    # Second pass: component tags with no folder + UpdateSector targets.
+    foreach ($f in Get-AppFiles) {
+        $rel = Get-RelPath $f.FullName
+        $c = Get-Content -Raw -LiteralPath $f.FullName
+        foreach ($m in $compTagRx.Matches($c)) {
+            $comp = $m.Groups[1].Value
+            if (-not $componentSet.Contains($comp)) {
+                $unresolvedComponents.Add([pscustomobject]@{ tag = "d-$comp"; file = $rel; line = Get-LineNumber $c $m.Index })
+            }
+        }
+        foreach ($m in $updateSectorRx.Matches($c)) {
+            $sec = $m.Groups[1].Value
+            if (-not $declaredSectors.Contains($sec)) {
+                $sectorUsages.Add([pscustomobject]@{ sector = $sec; file = $rel; line = Get-LineNumber $c $m.Index })
+            }
+        }
+    }
+
+    Write-Result ([pscustomobject]@{
+            command              = 'scan-unresolved'
+            unresolvedComponents = @($unresolvedComponents)
+            unresolvedSectorCandidates = @($sectorUsages)
+            notes                = 'unresolvedComponents are high-confidence (no matching folder under wwwroot/components). unresolvedSectorCandidates are UpdateSector() targets with no static d-sector declaration - many are legitimate (declared in dynamically loaded/parent content), so treat as candidates to review, not errors.'
+        })
+}
+
+switch ($Command) {
+    'resolve-datakey' { if (-not $Name) { throw 'resolve-datakey requires a key name' }; Invoke-ResolveDataKey $Name }
+    'resolve-sector' { if (-not $Name) { throw 'resolve-sector requires a sector name' }; Invoke-ResolveSector $Name }
+    'resolve-component' { if (-not $Name) { throw 'resolve-component requires a component tag/name' }; Invoke-ResolveComponent $Name }
+    'find-references' { if (-not $Name) { throw 'find-references requires a key name' }; Invoke-FindReferences $Name }
+    'scan-unresolved' { Invoke-ScanUnresolved }
+}

--- a/plugins/drapo-resolver/reference/troubleshooting.md
+++ b/plugins/drapo-resolver/reference/troubleshooting.md
@@ -1,0 +1,64 @@
+# Troubleshooting Drapo
+
+A symptom → likely cause → how to confirm → fix playbook. Confirm against the **running app**
+before guessing, then fix at the source.
+
+## Inspect the running app first
+
+When a Drapo app is loaded in the browser, the engine is exposed on `window.drapo`:
+
+- `window.drapo.Introspection.GetSnapshot()` → `{ state, sectors, dataKeysBySector, diagnostics }`. The fastest way to see *what is actually mounted*: which sectors exist and which data keys are live in each. (Via Playwright/Selenium: `page.evaluate(() => window.drapo.Introspection.GetSnapshot())`.)
+- `window.drapo.Diagnostics.GetErrorBuffer()` → recent client errors/warnings.
+- Press **Ctrl+F2** for the built-in visual debugger (highlight sectors/components, reload config).
+
+Pair this with the static tools: the resolver (`resolve-*`, `find-references`, `scan-unresolved`) for *what the source defines*, and the MCP `validate_drapo` for *whether the markup is legal*.
+
+## Symptom → cause → fix
+
+### Text shows literal `{{something}}` instead of a value
+- **Cause**: the element was never processed by Drapo — it's inside a `d-pre` block, or it lives in markup that was injected outside Drapo, or its sector never loaded.
+- **Confirm**: `GetSnapshot()` — is the expected sector in `sectors`? Is the key in `dataKeysBySector`?
+- **Fix**: ensure the markup is loaded into a Drapo sector (`UpdateSector`), and remove stray `d-pre`.
+
+### A binding/list doesn't update when data changes
+- **Cause**: the storage was changed in a way that didn't notify observers (e.g. mutated outside Drapo functions, or while `LockData` was in effect).
+- **Confirm**: does the value update after a `ReloadData`/`Notify`? Then it's a notification issue.
+- **Fix**: change storage via Drapo functions (`UpdateDataField`, `AddDataItem`, …) or call `Notify(key)`; unlock with `UnlockData` if you locked it.
+
+### Data never appears at all
+- **Cause** (in order of likelihood): the `d-dataKey` isn't declared; wrong `d-dataType`; the `d-dataUrlGet` request failed; `d-dataLoadType` defers loading.
+- **Confirm**: `resolve-datakey <key>` → `found:false` means it's undocumented in source. If declared, check `Diagnostics.GetErrorBuffer()` and the network tab for the `d-dataUrlGet` call.
+- **Fix**: declare the key / correct the type / fix the endpoint or load type.
+
+### `d-for` renders nothing (or errors)
+- **Cause**: the iterator isn't an array; the data key is wrong/undeclared; `d-for-if` is false; or the data hasn't loaded yet.
+- **Confirm**: `resolve-datakey <key>` (does it exist, and is `dataType` `array`?); `GetSnapshot()` to see if it's loaded.
+- **Fix**: point `d-for` at an array key that's loaded; verify the syntax is `alias in dataKey`.
+
+### A `<d-component>` renders nothing
+- **Cause**: no component folder matches the tag, or the component isn't registered from a scanned path, or the tag is misspelled.
+- **Confirm**: `resolve-component <tag>` → `found:false`; or `scan-unresolved` lists it under `unresolvedComponents`.
+- **Fix**: correct the tag, or create/register `wwwroot/components/<name>/<name>.html`.
+
+### `UpdateSector(...)` does nothing / wrong region updates
+- **Cause**: the target sector name doesn't exist in the current DOM, or the view URL 404s.
+- **Confirm**: `resolve-sector <name>` (declared in source?) and `GetSnapshot().sectors` (mounted right now?); check the network request for the view.
+- **Fix**: use a sector that exists; fix the `~/path/view.html` URL.
+
+### `d-model` isn't two-way
+- **Cause**: the element isn't an interactive control (then `d-model` is one-way), or the change event differs.
+- **Fix**: use a real form control; set `d-model-event` if the control fires a non-standard event.
+
+### A click/handler does nothing, or "Invalid Function" appears
+- **Cause**: an unknown function name, wrong argument count, or unbalanced `{{ }}` in the `d-on-*` expression.
+- **Confirm**: run the handler markup through MCP `validate_drapo`; check the name with `get_functions`.
+- **Fix**: correct the function name/arguments; balance mustaches.
+
+### A `d-*` attribute is silently ignored
+- **Cause**: typo'd or non-existent attribute (e.g. `d-modl`, `d-datapollingtimepsan`).
+- **Confirm**: MCP `validate_drapo` flags unknown attributes; `get_attributes` lists the real ones.
+- **Fix**: use the correct attribute name.
+
+## Rule of thumb
+
+Most "Drapo is broken" reports are one of: a **name that doesn't exist** (key/component/sector — use the resolver), **invalid syntax** (use `validate_drapo`), or **a sector/data that isn't loaded at runtime** (use `GetSnapshot()`). Check those three first.

--- a/plugins/drapo-resolver/reference/using-drapo-correctly.md
+++ b/plugins/drapo-resolver/reference/using-drapo-correctly.md
@@ -1,0 +1,65 @@
+# Using Drapo correctly
+
+Practical rules for writing Drapo that works. This is the *prescriptive* layer; for the full
+reference of every attribute/function/concept, query the Drapo MCP (`get_attributes`,
+`get_functions`, `get_concepts`, `get_*_details`). To confirm a symbol exists in *this* app,
+use the resolver (`resolve-datakey`/`resolve-component`/`resolve-sector`).
+
+## Storage & loading data
+
+- Declare every piece of state with `d-dataKey` and a `d-dataType` (`value`, `object`, `array`, `function`, `querystring`, `parent`, `mapping`, `pointer`, `query`, `switch`).
+- Initialize inline: `value` → `d-dataProperty="..."`; `object` → `d-dataProperty-<name>="..."`.
+- Load from the server with `d-dataUrlGet`; post changes back with `d-dataUrlSet` (use `PostData(key)`). Control *when* it loads with `d-dataLoadType`.
+- Storage declared inside a sector dies when the sector is cleared/replaced. For state that must survive navigation, declare it **outside any sector** (e.g. the root layout).
+- Manipulate storage with functions, not ad-hoc JS: `AddDataItem`, `RemoveDataItem`, `UpdateDataField`, `ClearDataField`, `PostData`, `ReloadData`.
+- **Do** name the key once and reuse it; **don't** bind a key you never declared (the #1 cause of "nothing shows up").
+
+## Data binding
+
+- One-way (read): `{{key.property}}` in any text node *or* attribute value (`src`, `href`, `class`, …). It re-evaluates whenever the storage changes.
+- Two-way: `d-model="{{key.property}}"` on a form control. For non-interactive elements `d-model` is one-way.
+- Expressions support nested paths (`{{order.address.city}}`), array length (`{{items.length}}`), and simple arithmetic/comparison inside attributes like `d-if`, `d-class`.
+- Bindings resolve in the **current sector's** storage context. A key from another sector won't resolve unless it's a parent/global key or shared via `d-sector-friend`.
+
+## Rendering (d-for / d-if)
+
+- Loop: `d-for="alias in dataKey"` — `dataKey` must be an **array** (or an object, which iterates as `{{prop.Key}}`/`{{prop.Value}}`). Inside, bind with the alias: `{{alias.field}}`.
+- Filter rows with `d-if="{{...}}"` on the `d-for` element (false → removed from DOM). Disable the whole loop with `d-for-if`.
+- Large lists: set `d-for-render="item"` to patch individual rows instead of re-rendering the whole list.
+- Ranges: `items[0..5]`, `items[1..^1]`, `items[^0..0]` (`^` indexes from the end).
+- `d-if` (conditional render) is the everyday tool; reach for `d-render` / `d-for-render` only for render-control.
+
+## Sectors & navigation
+
+- A `d-sector="name"` element is a region you can load/clear/replace independently.
+- Navigate by loading content into a sector: `UpdateSector(sectorName, ~/path/view.html)`. Clear with `ClearSector(sectorName)`.
+- Lifecycle on `UpdateSector`: fetch HTML → destroy the old content's storage/bindings → replace inner HTML → process Drapo attributes in the new markup (initializing nested sectors).
+- Convention-based layout: a child view can declare `d-parent`/`d-parentSector` to load itself into a parent layout's sector without an explicit `UpdateSector` call.
+- The first argument to `UpdateSector` must be a sector that actually exists in the current DOM — verify with `resolve-sector`.
+
+## Components
+
+- A component is a folder `wwwroot/components/<name>/` with `<name>.html` (+ optional `<name>.ts`, `.css`). Use it as `<d-<name>>`.
+- Pass data/config into a component instance with `dc-*` attributes (e.g. `dc-userName="{{user.name}}"`).
+- A `<d-foo>` tag with no matching component folder renders nothing — catch these with `scan-unresolved` / `resolve-component`.
+
+## Events
+
+- Attach behavior with `d-on-<event>` (e.g. `d-on-click`, `d-on-change`). The value is a sequence of Drapo function calls separated by `;` — no JavaScript.
+- `d-on-click="FuncA(...);FuncB(...)"` runs them in order. Debounce with `d-on-<event>-debounce`; prevent overlapping runs with `d-event-single`.
+- Every function name must be a real Drapo function — confirm with `validate_drapo` / `get_functions`. Watch argument counts and balanced `{{ }}`.
+
+## Validation, formatting, live data
+
+- **Validation**: declare a validator once as a hidden element, then reference it from interactive elements (to block) and display elements (to show messages). Run/clear with `ExecuteValidation` / `ClearValidation`.
+- **Formatting**: format numbers/dates/timespans in-template with `d-format`, and `d-culture` for locale-aware output. Don't hand-format in expressions.
+- **Live data**: use **Polling** (`d-dataPollingKey` + interval, calls `ReloadData` on change) for interval refresh, or **Pipes** (SignalR push) for server-pushed updates.
+
+## General do / don't
+
+- ✅ Confirm a key/component/sector exists (`resolve-*`) before binding to it.
+- ✅ Validate snippet syntax with `validate_drapo` before finishing an edit.
+- ✅ Use Drapo functions for state changes so change-tracking notifies the UI.
+- ❌ Don't write custom JavaScript to mutate the DOM that Drapo manages.
+- ❌ Don't bind across sectors without a parent/global/friend relationship.
+- ❌ Don't assume a binding works — verify it rendered (see `troubleshooting.md`).

--- a/src/WebDocs/wwwroot/app/menu/0001 - Guide/0018 - Drapo Resolver Skill.html
+++ b/src/WebDocs/wwwroot/app/menu/0001 - Guide/0018 - Drapo Resolver Skill.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>Drapo Resolver Skill</h2>
+        <p>The Drapo Resolver is an installable AI-agent skill that makes an LLM <strong>project-aware</strong>: it indexes a Drapo application's own frontend (<code>wwwroot/app</code> + <code>wwwroot/components</code>) and answers go-to-definition / find-references questions about the symbols <em>that app</em> defined — its <code>d-dataKey</code>s, components, and sectors. The shared Drapo MCP knows the framework (every function/attribute that <em>can</em> exist); this skill knows what <em>your</em> app actually contains, so an agent can confirm a binding key, component tag, or sector name really exists instead of guessing.</p>
+
+        <h3>How to install (Claude Code)</h3>
+        <p>The skill is distributed as a plugin from the <strong>drapo</strong> plugin marketplace, hosted in the <code>spadrapo/docs</code> repository. Add the marketplace and install the plugin:</p>
+        <pre><code>/plugin marketplace add spadrapo/docs
+/plugin install drapo-resolver@drapo</code></pre>
+        <p>Update later with <code>/plugin marketplace update drapo</code>.</p>
+
+        <h3>What it provides</h3>
+        <p>Once installed, the skill auto-activates when relevant and exposes a PowerShell resolver with these commands (all output JSON):</p>
+        <ul>
+            <li><code>resolve-datakey &lt;key&gt;</code> — where a <code>d-dataKey</code> is declared (file, line, <code>d-dataType</code>, URLs, value), or <code>found:false</code>.</li>
+            <li><code>resolve-component &lt;tag&gt;</code> — the component folder and its files (accepts <code>d-foo</code> or <code>foo</code>).</li>
+            <li><code>resolve-sector &lt;name&gt;</code> — where a <code>d-sector</code> is declared.</li>
+            <li><code>find-references &lt;key&gt;</code> — every declaration and reference site (mustache or <code>d-*</code> attribute).</li>
+            <li><code>scan-unresolved</code> — <code>&lt;d-x&gt;</code> component tags with no matching component (high-confidence), plus <code>UpdateSector</code> sector targets with no static declaration (candidates).</li>
+        </ul>
+
+        <h3>When to use it</h3>
+        <ul>
+            <li>Before binding to a data key, using a <code>&lt;d-component&gt;</code>, or targeting a sector you did not just author — confirm it exists.</li>
+            <li>After editing Drapo HTML — run <code>scan-unresolved</code> to catch component tags that point at nothing.</li>
+            <li>Before renaming a data key — use <code>find-references</code> to find every binding site.</li>
+        </ul>
+
+        <p>It is a generic Drapo skill: it only relies on Drapo conventions, so it works in any Drapo application. It runs locally because it reads the app's own files, which the hosted MCP cannot.</p>
+    </div>
+</div>


### PR DESCRIPTION
## What

Distributes the project-aware Drapo resolver as an **installable Claude Code plugin** (via a marketplace), and **advertises it through the MCP** so an LLM can discover it.

### 1. Marketplace + plugin
- `.claude-plugin/marketplace.json` — the **`drapo`** marketplace.
- `plugins/drapo-resolver/` — the plugin (`plugin.json` + `SKILL.md` + `drapo-resolver.ps1`).

Install (any Drapo app, no vendoring/copying):
```
/plugin marketplace add spadrapo/docs
/plugin install drapo-resolver@drapo
```

### 2. MCP discovery concept
- Guide concept **`0018 - Drapo Resolver Skill`** documents the skill and its install command. It surfaces via `get_concepts` / `get_concept_details`, so an LLM that has the Drapo MCP can **discover the skill exists and tell the user how to install it**.

## Why this shape
- A marketplace plugin gives native install + auto-updates and avoids copying the skill into every consumer repo.
- The skill stays generic (Drapo conventions only) and runs locally (it reads the app's own files, which the hosted MCP can't).
- The MCP is the *discovery* surface; installation is the client-side `/plugin` flow.

## Verification
- `claude plugin validate .` → **passed**.
- Discovery concept surfaces via the real `ConceptService` (count 17→18; `get_concept_details` includes the `/plugin marketplace add` command).
- Resolver logic unchanged; previously verified against PowerPlanning (361 pages, 54 components): all 5 commands work; `scan-unresolved` flagged a real dangling `<d-chatai>`.

Relates to t6-enterprise/powerplanning#8026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)