### PR TITLE
i292: Document the UpdateTokenAntiforgery function

### DIFF
--- a/src/WebDocs/wwwroot/app/functions/UpdateTokenAntiforgery/description.html
+++ b/src/WebDocs/wwwroot/app/functions/UpdateTokenAntiforgery/description.html
@@ -1,0 +1,1 @@
+<p>The UpdateTokenAntiforgery function updates the anti-forgery (CSRF) token that the Drapo client sends to the server on subsequent requests. Pass the new token value as the parameter. It is the anti-forgery counterpart of <code>UpdateToken</code>, which updates the authentication/session token.</p>

--- a/src/WebDocs/wwwroot/app/functions/UpdateTokenAntiforgery/parameters.json
+++ b/src/WebDocs/wwwroot/app/functions/UpdateTokenAntiforgery/parameters.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "Token",
+    "Description": "The new anti-forgery (CSRF) token value to use for subsequent server requests.",
+    "Types": [ "text", "mustache" ],
+    "Optional": false
+  }
+]

--- a/src/WebDocs/wwwroot/app/functions/UpdateTokenAntiforgery/samples/001/content.html
+++ b/src/WebDocs/wwwroot/app/functions/UpdateTokenAntiforgery/samples/001/content.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Function - UpdateTokenAntiforgery</title>
+</head>
+<body>
+    <br>
+    <span>UpdateTokenAntiforgery</span>
+    <div d-dataKey="auth" d-dataType="object" d-dataProperty-antiforgery=""></div>
+    <div>
+        <input type="text" d-model="{{auth.antiforgery}}" placeholder="new anti-forgery token">
+        <input type="button" value="Update token" d-on-click="UpdateTokenAntiforgery({{auth.antiforgery}})">
+    </div>
+</body>
+</html>

--- a/src/WebDocs/wwwroot/app/functions/UpdateTokenAntiforgery/samples/001/description.html
+++ b/src/WebDocs/wwwroot/app/functions/UpdateTokenAntiforgery/samples/001/description.html
@@ -1,0 +1,1 @@
+<p>Clicking the button updates the anti-forgery token used for server requests with the value held in storage.</p>


### PR DESCRIPTION
Closes #292.

Adds docs for **UpdateTokenAntiforgery** (description, 1 param `Token`, sample). Updates the anti-forgery/CSRF token the client sends on subsequent requests; counterpart of `UpdateToken`. Grounded in the engine (`ExecuteFunctionUpdateTokenAntiforgery` → `Server.SetTokenAntiforgery(token)`). Verified via `FunctionService`: signature `UpdateTokenAntiforgery(Token: text|mustache)`, 1 sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)