### PR TITLE
i293: Document the Wait function

### DIFF
--- a/src/WebDocs/wwwroot/app/functions/Wait/description.html
+++ b/src/WebDocs/wwwroot/app/functions/Wait/description.html
@@ -1,0 +1,1 @@
+<p>The Wait function pauses the execution of a function chain for a number of milliseconds before the next function runs. It is useful for sequencing actions that need a short delay between them. The wait time is parsed as a number (an invalid or missing value is treated as 0).</p>

--- a/src/WebDocs/wwwroot/app/functions/Wait/parameters.json
+++ b/src/WebDocs/wwwroot/app/functions/Wait/parameters.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Name": "Time",
+    "Description": "The number of milliseconds to wait before continuing. Parsed as a number; invalid values are treated as 0.",
+    "Types": [ "number", "mustache" ],
+    "Optional": false
+  }
+]

--- a/src/WebDocs/wwwroot/app/functions/Wait/samples/001/content.html
+++ b/src/WebDocs/wwwroot/app/functions/Wait/samples/001/content.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/drapo.js"></script>
+    <title>Function - Wait</title>
+</head>
+<body>
+    <br>
+    <span>Wait</span>
+    <div d-dataKey="data" d-dataType="object" d-dataProperty-status=""></div>
+    <div>
+        <input type="button" value="Run with delay"
+               d-on-click="UpdateDataField(data,status,working...);Wait(1000);UpdateDataField(data,status,done)">
+        <p>Status: {{data.status}}</p>
+    </div>
+</body>
+</html>

--- a/src/WebDocs/wwwroot/app/functions/Wait/samples/001/description.html
+++ b/src/WebDocs/wwwroot/app/functions/Wait/samples/001/description.html
@@ -1,0 +1,1 @@
+<p>Clicking the button sets a status, waits one second via <code>Wait(1000)</code>, then updates the status again.</p>


### PR DESCRIPTION
Closes #293.

Adds docs for **Wait** (description, 1 param `Time`, sample). Pauses the function chain for N milliseconds before continuing; the value is parsed as a number (invalid → 0). Grounded in the engine (`ExecuteFunctionWait` → `Parser.ParseNumber` + `Document.Sleep`). Verified via `FunctionService`: signature `Wait(Time: number|mustache)`, 1 sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)