### PR TITLE
Document the d-resize-* attributes

### DIFF
--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0121 - d-resize-class.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0121 - d-resize-class.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-resize-class</h2>
+        <p>You can use d-resize-class to set a CSS class that is applied while a resize is in progress (for example a visual cue on the element or container being resized). It is part of the resize behavior enabled by <code>d-resize-location</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0122 - d-resize-container.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0122 - d-resize-container.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-resize-container</h2>
+        <p>You can use d-resize-container to choose which ancestor element is resized, expressed as the number of levels up from the resize handle. It is parsed as a number and defaults to <code>2</code>. It is part of the resize behavior enabled by <code>d-resize-location</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0123 - d-resize-location.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0123 - d-resize-location.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-resize-location</h2>
+        <p>You can use d-resize-location to enable drag-to-resize behavior on an element and identify the location/dimension being resized. When this attribute is present the element becomes a resize handle: pressing and dragging it resizes the target container. This is the attribute that activates the behavior; the others configure it.</p>
+        <p>Configure the behavior with:</p>
+        <ul>
+            <li><code>d-resize-model</code> — storage path bound to the resulting size</li>
+            <li><code>d-resize-type</code> — resize mode (default <code>normal</code>)</li>
+            <li><code>d-resize-class</code> — CSS class applied while resizing</li>
+            <li><code>d-resize-container</code> — which ancestor is resized (levels up; default 2)</li>
+            <li><code>d-resize-preview</code> — live preview while dragging (default false)</li>
+        </ul>
+        <p>Syntax:</p>
+        <d-code>
+            &lt;div d-resize-location="..." d-resize-model="{{layout.width}}" d-resize-container="1" d-resize-preview="true"&gt;&lt;/div&gt;
+        </d-code>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0124 - d-resize-model.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0124 - d-resize-model.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-resize-model</h2>
+        <p>You can use d-resize-model to bind the resized size to a storage path. As the resize handle is dragged, the resulting size is written to (and read from) this data path. It is part of the resize behavior enabled by <code>d-resize-location</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0125 - d-resize-preview.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0125 - d-resize-preview.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-resize-preview</h2>
+        <p>You can use d-resize-preview to control when the new size is applied during a resize. When true, the size updates live as you drag (preview); when false (the default), the size is applied only when you release the mouse button. It is part of the resize behavior enabled by <code>d-resize-location</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0126 - d-resize-type.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0126 - d-resize-type.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-resize-type</h2>
+        <p>You can use d-resize-type to set the resize mode of the resize behavior. It defaults to <code>normal</code>. It is part of the resize behavior enabled by <code>d-resize-location</code>.</p>
+    </div>
+</div>


### PR DESCRIPTION
Closes #334, #335, #336, #337, #338, #339.

Documents the drag-to-resize behavior family (from `DrapoBehaviorHandler`):
- **d-resize-location** — enables the behavior; the element becomes a resize handle.
- **d-resize-model** — storage path bound to the size.
- **d-resize-type** — resize mode (default `normal`).
- **d-resize-class** — CSS class applied while resizing.
- **d-resize-container** — which ancestor is resized (levels up; default 2).
- **d-resize-preview** — live preview while dragging (default false).

Verified via `AttributeService`: all six appear in `get_attributes` with details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)