### PR TITLE
Document the d-drag* attributes (drag-and-drop)

### DIFF
--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0127 - d-dragAction.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0127 - d-dragAction.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragAction</h2>
+        <p>You can use d-dragAction to control what happens when a dragged item is dropped: <code>move</code> (the default) moves the item from the source collection to the target, and <code>custom</code> runs the Drapo expression given in <code>d-dragActionCustom</code>. It is part of the drag-and-drop behavior enabled by <code>d-dragStart</code> / <code>d-dragEnd</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0128 - d-dragActionCustom.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0128 - d-dragActionCustom.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragActionCustom</h2>
+        <p>You can use d-dragActionCustom to provide the Drapo function expression that runs on drop when <code>d-dragAction</code> is set to <code>custom</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0129 - d-dragEnd.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0129 - d-dragEnd.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragEnd</h2>
+        <p>You can use d-dragEnd to mark an element as a <strong>drop target</strong> for Drapo drag-and-drop. Its value is the tag (or tags) it accepts, matched against the tags declared by drag sources (<code>d-dragStart</code>). Bind the target collection with <code>d-dragEndDataKey</code> and choose what happens on drop with <code>d-dragAction</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0130 - d-dragEndDataKey.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0130 - d-dragEndDataKey.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragEndDataKey</h2>
+        <p>You can use d-dragEndDataKey to bind the storage data key associated with a drop target (the collection a dragged item is dropped into). Used together with <code>d-dragEnd</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0131 - d-dragNotify.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0131 - d-dragNotify.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragNotify</h2>
+        <p>You can use d-dragNotify to control whether observers are notified after a drag-and-drop operation changes the data. It defaults to <code>true</code>.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0132 - d-dragOnAfterEnd.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0132 - d-dragOnAfterEnd.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragOnAfterEnd</h2>
+        <p>You can use d-dragOnAfterEnd to run a Drapo function expression after a drop completes. It is a lifecycle hook of the drag-and-drop behavior.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0133 - d-dragOnBeforeStart.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0133 - d-dragOnBeforeStart.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragOnBeforeStart</h2>
+        <p>You can use d-dragOnBeforeStart to run a Drapo function expression before a drag starts. It is a lifecycle hook of the drag-and-drop behavior.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0134 - d-dragStart.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0134 - d-dragStart.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragStart</h2>
+        <p>You can use d-dragStart to mark an element as a <strong>drag source</strong> for Drapo drag-and-drop. When present the element becomes draggable, and its value is the tag (or tags) identifying the draggable item/group, matched against drop targets declared with <code>d-dragEnd</code>.</p>
+        <p>Configure it with:</p>
+        <ul>
+            <li><code>d-dragStartDataKey</code> — the source collection the item comes from</li>
+            <li><code>d-dragAction</code> — what happens on drop (<code>move</code> default, or <code>custom</code> + <code>d-dragActionCustom</code>)</li>
+            <li><code>d-dragNotify</code> — notify observers after the change (default true)</li>
+            <li><code>d-dragOnBeforeStart</code> / <code>d-dragOnAfterEnd</code> — lifecycle hooks</li>
+        </ul>
+        <p>Syntax:</p>
+        <d-code>
+            &lt;li d-for="item in items" d-dragStart="row" d-dragStartDataKey="items"&gt;{{item.name}}&lt;/li&gt;
+            &lt;div d-dragEnd="row" d-dragEndDataKey="basket"&gt;Drop here&lt;/div&gt;
+        </d-code>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0135 - d-dragStartDataKey.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0135 - d-dragStartDataKey.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dragStartDataKey</h2>
+        <p>You can use d-dragStartDataKey to bind the storage data key associated with a drag source (the collection the dragged item comes from). Used together with <code>d-dragStart</code>.</p>
+    </div>
+</div>


### PR DESCRIPTION
Closes #322, #323, #324, #325, #326, #327, #328, #329, #330.

Documents the drag-and-drop behavior family (from `DrapoBehaviorHandler`):
- **d-dragStart** (source) / **d-dragEnd** (drop target) — matched by tag.
- **d-dragAction** (`move` default / `custom`) + **d-dragActionCustom**.
- **d-dragStartDataKey** / **d-dragEndDataKey** — source/target collections.
- **d-dragNotify** (default true), **d-dragOnBeforeStart** / **d-dragOnAfterEnd** hooks.

Verified via `AttributeService`: all nine appear in `get_attributes` with details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)