### PR TITLE
Document the remaining d-data* storage attributes (21)

### DIFF
--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0136 - d-dataMappingField.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0136 - d-dataMappingField.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataMappingField</h2>
+        <p>You can use d-dataMappingField on a storage item of type mapping to identify the field used to map between the source and the mapped data.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0137 - d-dataMappingSearchField.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0137 - d-dataMappingSearchField.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataMappingSearchField</h2>
+        <p>You can use d-dataMappingSearchField on a mapping storage item to set the field that is searched when resolving the mapping.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0138 - d-dataMappingSearchHierarchyField.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0138 - d-dataMappingSearchHierarchyField.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataMappingSearchHierarchyField</h2>
+        <p>You can use d-dataMappingSearchHierarchyField on a mapping storage item to set the field that defines the hierarchy when searching hierarchical (tree) data.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0139 - d-dataMappingSearchValue.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0139 - d-dataMappingSearchValue.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataMappingSearchValue</h2>
+        <p>You can use d-dataMappingSearchValue on a mapping storage item to set the value to search for when resolving the mapping.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0140 - d-dataMappingSubscribe.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0140 - d-dataMappingSubscribe.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataMappingSubscribe</h2>
+        <p>You can use d-dataMappingSubscribe (true/false) on a mapping storage item to control whether the mapping subscribes to changes in the source data and updates automatically. Defaults to false.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0141 - d-dataLazy.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0141 - d-dataLazy.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataLazy</h2>
+        <p>You can use d-dataLazy (true/false) to enable lazy, incremental loading of a storage item so it is fetched in pages instead of all at once. Pair it with d-dataLazyStart and d-dataLazyIncrement.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0142 - d-dataLazyIncrement.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0142 - d-dataLazyIncrement.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataLazyIncrement</h2>
+        <p>You can use d-dataLazyIncrement to set how many items are loaded per page when lazy loading is enabled with d-dataLazy.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0143 - d-dataLazyStart.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0143 - d-dataLazyStart.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataLazyStart</h2>
+        <p>You can use d-dataLazyStart to set the starting offset (the first index) when lazy loading is enabled with d-dataLazy.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0144 - d-dataOnAfterCached.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0144 - d-dataOnAfterCached.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataOnAfterCached</h2>
+        <p>You can use d-dataOnAfterCached to run a Drapo function expression after the storage item has been cached.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0145 - d-dataOnAfterContainerLoad.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0145 - d-dataOnAfterContainerLoad.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataOnAfterContainerLoad</h2>
+        <p>You can use d-dataOnAfterContainerLoad to run a Drapo function expression after the storage item container has loaded.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0146 - d-dataOnAfterLoad.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0146 - d-dataOnAfterLoad.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataOnAfterLoad</h2>
+        <p>You can use d-dataOnAfterLoad to run a Drapo function expression after the storage item has finished loading its data.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0147 - d-dataOnBeforeContainerUnLoad.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0147 - d-dataOnBeforeContainerUnLoad.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataOnBeforeContainerUnLoad</h2>
+        <p>You can use d-dataOnBeforeContainerUnLoad to run a Drapo function expression before the storage item container is unloaded.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0148 - d-dataConfigGet.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0148 - d-dataConfigGet.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataConfigGet</h2>
+        <p>You can use d-dataConfigGet to populate a storage item from a Drapo configuration value instead of (or in addition to) a server endpoint.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0149 - d-dataCookieChange.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0149 - d-dataCookieChange.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataCookieChange</h2>
+        <p>You can use d-dataCookieChange (true/false) to write changes of the storage item back to its cookie, keeping the cookie in sync. Used together with d-dataCookieGet.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0150 - d-dataCookieGet.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0150 - d-dataCookieGet.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataCookieGet</h2>
+        <p>You can use d-dataCookieGet to initialise a storage item from a browser cookie, naming the cookie to read.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0151 - d-dataDelay.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0151 - d-dataDelay.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataDelay</h2>
+        <p>You can use d-dataDelay (true/false) to delay loading a storage item until it is actually needed rather than loading it eagerly.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0152 - d-dataGroups.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0152 - d-dataGroups.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataGroups</h2>
+        <p>You can use d-dataGroups to associate a storage item with one or more groups, allowing grouped operations (such as loading or reloading several related items together).</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0153 - d-dataQueryArray.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0153 - d-dataQueryArray.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataQueryArray</h2>
+        <p>You can use d-dataQueryArray with the client-side query engine to provide the array(s) a query operates over. See the Data Querying guide.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0154 - d-dataToken.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0154 - d-dataToken.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataToken</h2>
+        <p>You can use d-dataToken (true/false) to indicate that requests for this storage item should include the authentication token.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0155 - d-dataUnitOfWork.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0155 - d-dataUnitOfWork.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataUnitOfWork</h2>
+        <p>You can use d-dataUnitOfWork (true/false) to treat a storage item as a unit of work, tracking added/updated/removed items so the differences can be posted to the server (see PostData).</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0156 - d-dataUserConfig.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0156 - d-dataUserConfig.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-dataUserConfig</h2>
+        <p>You can use d-dataUserConfig to populate a storage item from user-specific configuration.</p>
+    </div>
+</div>


### PR DESCRIPTION
Closes #298, #299, #300, #301, #302, #303, #304, #305, #306, #307, #308, #309, #310, #311, #312, #313, #314, #316, #317, #318, #319.

Documents the storage-item modifier attributes (grounded in `DrapoStorage`), grouped:
- **Mapping:** `d-dataMappingField`, `d-dataMappingSearchField`, `d-dataMappingSearchHierarchyField`, `d-dataMappingSearchValue`, `d-dataMappingSubscribe`
- **Lazy loading:** `d-dataLazy`, `d-dataLazyStart`, `d-dataLazyIncrement`
- **Lifecycle hooks:** `d-dataOnAfterLoad`, `d-dataOnAfterContainerLoad`, `d-dataOnAfterCached`, `d-dataOnBeforeContainerUnLoad`
- **Misc:** `d-dataConfigGet`, `d-dataCookieGet`, `d-dataCookieChange`, `d-dataDelay`, `d-dataGroups`, `d-dataQueryArray`, `d-dataToken`, `d-dataUnitOfWork`, `d-dataUserConfig`

All 21 verified present in `get_attributes` via `AttributeService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)