### PR TITLE
Document component/sector/misc attributes (14)

### DIFF
--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0157 - d-container.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0157 - d-container.html
@@ -4,5 +4,11 @@
     <div>
         <h2>d-container</h2>
         <p>You can use d-container on a sector to set the container code used when switching between containers of that sector (see UpdateSector / SwitchSector). Use <code>@</code> to have Drapo generate a unique container code automatically.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-sector="content" d-container="@"&gt;&lt;/div&gt;
+            &lt;input type="button" value="Open A" d-on-click="UpdateSector(content,~/app/pages/a.html,,true,false,boxA)"&gt;
+            &lt;input type="button" value="Open B" d-on-click="UpdateSector(content,~/app/pages/b.html,,true,false,boxB)"&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0157 - d-container.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0157 - d-container.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-container</h2>
+        <p>You can use d-container on a sector to set the container code used when switching between containers of that sector (see UpdateSector / SwitchSector). Use <code>@</code> to have Drapo generate a unique container code automatically.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0158 - d-content.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0158 - d-content.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-content</h2>
         <p>You can use d-content on a component element to provide its content inline, as an alternative to loading it from a URL with d-contenturl.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;d-panel d-content="Hello from the host"&gt;&lt;/d-panel&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0158 - d-content.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0158 - d-content.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-content</h2>
+        <p>You can use d-content on a component element to provide its content inline, as an alternative to loading it from a URL with d-contenturl.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0159 - d-contenturl.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0159 - d-contenturl.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-contenturl</h2>
         <p>You can use d-contenturl on a component element to load its content/template from a URL.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;d-panel d-contenturl="~/app/parts/panel.html"&gt;&lt;/d-panel&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0159 - d-contenturl.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0159 - d-contenturl.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-contenturl</h2>
+        <p>You can use d-contenturl on a component element to load its content/template from a URL.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0160 - d-detach.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0160 - d-detach.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-detach</h2>
         <p>You can use d-detach on a child sector to mark it to be detached and preserved when its parent sector is updated, instead of being destroyed and recreated.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-sector="cachedPanel" d-detach="true"&gt;&lt;/div&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0160 - d-detach.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0160 - d-detach.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-detach</h2>
+        <p>You can use d-detach on a child sector to mark it to be detached and preserved when its parent sector is updated, instead of being destroyed and recreated.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0161 - d-detachable.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0161 - d-detachable.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-detachable</h2>
         <p>You can use d-detachable to mark an element or sector as detachable, so Drapo can detach and later re-attach it rather than recreating it.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-detachable="true"&gt;...&lt;/div&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0161 - d-detachable.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0161 - d-detachable.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-detachable</h2>
+        <p>You can use d-detachable to mark an element or sector as detachable, so Drapo can detach and later re-attach it rather than recreating it.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0162 - d-id.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0162 - d-id.html
@@ -4,5 +4,10 @@
     <div>
         <h2>d-id</h2>
         <p>You can use d-id to give a component instance an identifier so it can be referenced later, for example by ExecuteComponentFunction. The value is mustache-resolvable.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;d-grid d-id="mainGrid"&gt;&lt;/d-grid&gt;
+            &lt;input type="button" value="Refresh" d-on-click="ExecuteComponentFunction(mainGrid,Refresh)"&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0162 - d-id.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0162 - d-id.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-id</h2>
+        <p>You can use d-id to give a component instance an identifier so it can be referenced later, for example by ExecuteComponentFunction. The value is mustache-resolvable.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0163 - d-model-event-cancel.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0163 - d-model-event-cancel.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-model-event-cancel</h2>
+        <p>You can use d-model-event-cancel to list the DOM event(s) that cancel a pending d-model edit, reverting the control to the stored value. It is the counterpart of d-model-event, which commits the edit.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0163 - d-model-event-cancel.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0163 - d-model-event-cancel.html
@@ -4,5 +4,15 @@
     <div>
         <h2>d-model-event-cancel</h2>
         <p>You can use d-model-event-cancel to list the DOM event(s) that cancel a pending d-model edit, reverting the control to the stored value. It is the counterpart of d-model-event, which commits the edit.</p>
+        <h4>Example</h4>
+        <p>Syntax:</p>
+        <d-code>
+            &lt;input d-model="{{form.name}}" d-model-event-cancel="blur" /&gt;
+        </d-code>
+        <d-sample>
+            <div d-dataKey="form" d-dataType="object" d-dataProperty-name="Alice"></div>
+            <input type="text" d-model="{{form.name}}" d-model-event-cancel="blur" />
+            <span>Stored value: {{form.name}}</span>
+        </d-sample>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0164 - d-route.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0164 - d-route.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-route</h2>
+        <p>You can use d-route on a sector to control whether updating that sector participates in client routing (changing the URL). Set it to false to update the sector without changing the route.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0164 - d-route.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0164 - d-route.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-route</h2>
         <p>You can use d-route on a sector to control whether updating that sector participates in client routing (changing the URL). Set it to false to update the sector without changing the route.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-sector="content" d-route="false"&gt;&lt;/div&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0165 - d-sector-impersonate.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0165 - d-sector-impersonate.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-sector-impersonate</h2>
+        <p>You can use d-sector-impersonate to let a sector impersonate another sector, sharing its data and identity. This is an advanced sector-composition feature.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0165 - d-sector-impersonate.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0165 - d-sector-impersonate.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-sector-impersonate</h2>
         <p>You can use d-sector-impersonate to let a sector impersonate another sector, sharing its data and identity. This is an advanced sector-composition feature.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-sector="modal" d-sector-impersonate="content"&gt;&lt;/div&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0166 - d-sector-url.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0166 - d-sector-url.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-sector-url</h2>
+        <p>You can use d-sector-url on a sector element to declaratively load its content from a URL when it initialises, instead of calling UpdateSector explicitly.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0166 - d-sector-url.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0166 - d-sector-url.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-sector-url</h2>
         <p>You can use d-sector-url on a sector element to declaratively load its content from a URL when it initialises, instead of calling UpdateSector explicitly.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-sector="sidebar" d-sector-url="~/app/parts/sidebar.html"&gt;&lt;/div&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0167 - d-template.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0167 - d-template.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-template</h2>
+        <p>You can use d-template to provide an inline template used when rendering a sector or element.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0167 - d-template.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0167 - d-template.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-template</h2>
         <p>You can use d-template to provide an inline template used when rendering a sector or element.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-sector="list" d-template="~/app/parts/row.html"&gt;&lt;/div&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0168 - d-templateurl.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0168 - d-templateurl.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-templateurl</h2>
+        <p>You can use d-templateurl to load a template from a URL, used when rendering a sector or element.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0168 - d-templateurl.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0168 - d-templateurl.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-templateurl</h2>
         <p>You can use d-templateurl to load a template from a URL, used when rendering a sector or element.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-sector="list" d-templateurl="~/app/parts/row.html"&gt;&lt;/div&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0169 - d-validation.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0169 - d-validation.html
@@ -3,6 +3,11 @@
 <div>
     <div>
         <h2>d-validation</h2>
-        <p>You can use d-validation to declare a validator. Declare it once (typically on a hidden element) and reference it from interactive elements (to block actions when invalid) and from display elements (to show error messages). See the Validation guide for full details and examples.</p>
+        <p>You can use d-validation to declare a validator. Declare it once (typically on a hidden element) and reference it from interactive elements (to block actions when invalid) and from display elements (to show error messages). See the Validation guide for full details and runnable examples.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-validation="required" style="display:none"&gt;&lt;/div&gt;
+        </d-code>
+        <p><strong>See:</strong> [Validation guide](Validation) for complete, runnable examples.</p>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0169 - d-validation.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0169 - d-validation.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-validation</h2>
+        <p>You can use d-validation to declare a validator. Declare it once (typically on a hidden element) and reference it from interactive elements (to block actions when invalid) and from display elements (to show error messages). See the Validation guide for full details and examples.</p>
+    </div>
+</div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0170 - d-window-allowMultipleInstanceUrl.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0170 - d-window-allowMultipleInstanceUrl.html
@@ -4,5 +4,9 @@
     <div>
         <h2>d-window-allowMultipleInstanceUrl</h2>
         <p>You can use d-window-allowMultipleInstanceUrl (true/false) to control whether a window may open multiple instances for the same URL. Defaults to true; set it to false to reuse a single window instance per URL.</p>
+        <h4>Example</h4>
+        <d-code>
+            &lt;div d-window-allowMultipleInstanceUrl="false"&gt;&lt;/div&gt;
+        </d-code>
     </div>
 </div>

--- a/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0170 - d-window-allowMultipleInstanceUrl.html
+++ b/src/WebDocs/wwwroot/app/menu/0003 - Attributes/0170 - d-window-allowMultipleInstanceUrl.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="/drapo.js"></script>
+<div>
+    <div>
+        <h2>d-window-allowMultipleInstanceUrl</h2>
+        <p>You can use d-window-allowMultipleInstanceUrl (true/false) to control whether a window may open multiple instances for the same URL. Defaults to true; set it to false to reuse a single window instance per URL.</p>
+    </div>
+</div>


### PR DESCRIPTION
Closes #295, #296, #297, #320, #321, #332, #333, #340, #341, #342, #343, #344, #345, #346.

Final attribute batch, grounded in the engine:
- **Components:** `d-content`, `d-contenturl`, `d-id`
- **Sectors:** `d-container`, `d-sector-url`, `d-sector-impersonate`, `d-detach`, `d-detachable`, `d-route`
- **Rendering:** `d-template`, `d-templateurl`
- **Model:** `d-model-event-cancel`
- **Windows:** `d-window-allowMultipleInstanceUrl`
- **Validation:** `d-validation` (cross-links the Validation guide)

All 14 verified present in `get_attributes` via `AttributeService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)