### PR TITLE
Fix validate_drapo false positives on d-validation-*/d-dataproperty-* (engine reads them via generic attribute parsing, not literal dispatch)

### DIFF
--- a/src/WebDocs/Services/DrapoEngineCatalog.cs
+++ b/src/WebDocs/Services/DrapoEngineCatalog.cs
@@ -20,6 +20,17 @@ namespace WebDocs.Services
         // Attributes appear only as string literals (no central dispatch).
         private static readonly Regex AttributeRegex = new Regex(@"['""](d-[a-z][a-z-]*)['""]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        // Prefix families the literal-scraper below cannot discover: the engine reads these via
+        // fully-generic attribute.nodeName inspection (parsing the DOM attribute name at runtime,
+        // e.g. DrapoValidator.ExtractValidations -> ExtractValidationProperty, and
+        // DrapoStorage.RetrieveDataProperty), never via a literal 'd-prefix-' string concatenation
+        // the way d-attr-/d-on- are (those work today because 'd-attr-'/'d-on-' DO appear as
+        // isolated quoted literals in DrapoAttributeHandler.ts/DrapoEventHandler.ts). Confirmed by
+        // reading the TS source directly - these two produced false "unknown-attribute" errors on
+        // genuinely valid, shipped markup (d-validation-id/-type/-value/-expression/-group,
+        // d-dataproperty-<name>-name/-value) until this list was added.
+        private static readonly string[] KnownDynamicPrefixes = { "d-validation-", "d-dataproperty-" };
+
         private static readonly object Lock = new object();
         private static HashSet<string> _functions;
         private static HashSet<string> _attributes;
@@ -69,7 +80,9 @@ namespace WebDocs.Services
                 string js = ReadEngineJs(engine);
                 _functions = new HashSet<string>(FunctionRegex.Matches(js).Select(m => m.Groups[1].Value.ToLowerInvariant()));
                 _attributes = new HashSet<string>(AttributeRegex.Matches(js).Select(m => m.Groups[1].Value.ToLowerInvariant()));
-                _attributePrefixes = _attributes.Where(a => a.EndsWith("-", StringComparison.Ordinal)).ToList();
+                _attributePrefixes = _attributes.Where(a => a.EndsWith("-", StringComparison.Ordinal))
+                    .Union(KnownDynamicPrefixes)
+                    .ToList();
                 _version = ResolveVersion(engine);
             }
         }


### PR DESCRIPTION
## What

`validate_drapo` (the MCP tool `WebDocs.Tools.ValidationTool` exposes) reports `d-validation-id`, `-type`, `-value`, `-expression`, `-group`, and `d-dataproperty-<name>-name`/`-value` as `unknown-attribute` on genuinely valid, shipped markup.

## Root cause

`DrapoEngineCatalog.IsValidAttribute()` discovers attributes by regex-scraping the embedded `drapo.js` for quoted string literals matching `d-[a-z][a-z-]*`, plus a "dynamic prefix" fallback for families like `d-on-{event}` — that fallback only works when the *prefix itself* (e.g. `'d-on-'`) appears as an **isolated string literal** somewhere in the source (it does, in `DrapoEventHandler.ts`/`DrapoAttributeHandler.ts`, via concatenation like `'d-on-' + eventType`).

`d-validation-*` and `d-dataproperty-*` are real, implemented attributes — but the engine reads them via **fully generic `attribute.nodeName` inspection** at runtime (`DrapoValidator.ExtractValidations` → `ExtractValidationProperty`, and `DrapoStorage.RetrieveDataProperty`). No isolated `'d-validation-'` or `'d-dataproperty-'` string literal exists anywhere in the compiled engine for the scraper to find, so the prefix-family fallback never registers them — a structural blind spot of the literal-scraping heuristic, not a documentation gap.

## Fix

A small, clearly-commented `KnownDynamicPrefixes` list, unioned into the scraped prefix set at parse time, for exactly this class of engine-side generic-parsing attribute family the scraper can't discover on its own.

## Verification

Built a standalone harness directly exercising the real `DrapoEngineCatalog` + `DrapoValidatorService` (no mocking of the engine — it reads the actual embedded `drapo.js`) against the exact markup that failed live:

| | Errors |
|---|---|
| Before this fix | **7** (`d-validation-id`, `-type`, `-value`, `-expression`, `-group`, `d-dataproperty-<name>-name`, `-value`) |
| After this fix | **0** — `Valid: true` |

Confirmed via `git stash`/`stash pop` on `DrapoEngineCatalog.cs` — same harness, same input, only the fix toggled. Also confirmed `d-validation` (bare) and `d-validation-on-click` already validated correctly *before* this change (their literals already exist in the engine source) — this fix doesn't touch or affect those.

`dotnet build src/WebDocs/WebDocs.csproj` — 0 errors.

## Note

I originally (mistakenly) tried to fix this in `spadrapo/drapo`'s `HelpController.cs` (a documentation/help-text catalog for that repo's own demo app) — that file has **no effect whatsoever** on `validate_drapo`, which only ever reads `DrapoEngineCatalog` as implemented here. Flagging in case anyone else goes looking there first.