### PR TITLE
docs(668): document the Round function

### DIFF
--- a/src/WebDocs/WebDocs.csproj
+++ b/src/WebDocs/WebDocs.csproj
@@ -4,7 +4,7 @@
 		<TypeScriptToolsVersion>3.7</TypeScriptToolsVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Drapo" Version="2026.6.30.2">
+		<PackageReference Include="Drapo" Version="2026.8.4.3">
 			<ExcludeAssets>contentfiles</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />

--- a/src/WebDocs/wwwroot/app/functions/Round/description.html
+++ b/src/WebDocs/wwwroot/app/functions/Round/description.html
@@ -1,0 +1,14 @@
+<p>The Round function rounds a numeric expression to a given number of decimal places, using the rounding direction you choose. It mirrors the rounding functions found in mainstream programming languages and adds explicit <strong>floor</strong> and <strong>ceiling</strong> directions.</p>
+<p>The signature is <code>Round(value, digits, mode)</code>:</p>
+<ul>
+    <li><strong>value</strong> (required) &mdash; the numeric expression to round. Mustache and arithmetic expressions are resolved before rounding, so Round composes with <code>Cast</code> and any other expression.</li>
+    <li><strong>digits</strong> (optional, default <code>0</code>) &mdash; the number of decimal places to round to.</li>
+    <li><strong>mode</strong> (optional, default <code>round</code>) &mdash; the rounding direction:
+        <ul>
+            <li><code>round</code> &mdash; nearest value; exact halves are rounded <em>away from zero</em> (<code>2.5</code> &rarr; <code>3</code>, <code>-2.5</code> &rarr; <code>-3</code>).</li>
+            <li><code>floor</code> &mdash; toward negative infinity (<code>2.9</code> &rarr; <code>2</code>, <code>-2.1</code> &rarr; <code>-3</code>).</li>
+            <li><code>ceiling</code> &mdash; toward positive infinity (<code>2.1</code> &rarr; <code>3</code>, <code>-2.9</code> &rarr; <code>-2</code>).</li>
+        </ul>
+    </li>
+</ul>
+<p>An unrecognized <code>mode</code> falls back to the default <code>round</code> behavior. Because Round returns a number, it can be displayed with <code>d-model</code>, stored with <code>UpdateItemField</code>, or nested inside other functions.</p>

--- a/src/WebDocs/wwwroot/app/functions/Round/parameters.json
+++ b/src/WebDocs/wwwroot/app/functions/Round/parameters.json
@@ -1,0 +1,20 @@
+[
+  {
+    "Name": "value",
+    "Description": "The numeric expression to round. Mustache and arithmetic expressions are resolved before rounding.",
+    "Types": [ "expression" ],
+    "Optional": false
+  },
+  {
+    "Name": "digits",
+    "Description": "The number of decimal places to round to. Defaults to 0.",
+    "Types": [ "number" ],
+    "Optional": true
+  },
+  {
+    "Name": "mode",
+    "Description": "The rounding direction: round (nearest, ties away from zero), floor (toward negative infinity) or ceiling (toward positive infinity). Defaults to round.",
+    "Types": [ "type" ],
+    "Optional": true
+  }
+]

--- a/src/WebDocs/wwwroot/app/functions/Round/samples/001/content.html
+++ b/src/WebDocs/wwwroot/app/functions/Round/samples/001/content.html
@@ -1,0 +1,12 @@
+<div d-datakey="object" d-datatype="object" d-dataproperty-value="2.567" d-dataproperty-digits="2"></div>
+<div>
+    <span>Value: </span><input type="text" d-model="{{object.value}}" /><br />
+    <span>Digits: </span><input type="text" d-model="{{object.digits}}" /><br />
+    <br />
+    <span>Round (nearest): </span><span d-model="Round({{object.value}},{{object.digits}})"></span><br />
+    <span>Round floor: </span><span d-model="Round({{object.value}},{{object.digits}},floor)"></span><br />
+    <span>Round ceiling: </span><span d-model="Round({{object.value}},{{object.digits}},ceiling)"></span><br />
+    <br />
+    <span>Round to whole (nearest): </span><span d-model="Round({{object.value}})"></span><br />
+    <span>Round with Cast: </span><span d-model="Round(Cast({{object.value}} * 2,number),0,ceiling)"></span><br />
+</div>

--- a/src/WebDocs/wwwroot/app/functions/Round/samples/001/description.html
+++ b/src/WebDocs/wwwroot/app/functions/Round/samples/001/description.html
@@ -1,0 +1,1 @@
+<p>Change the value and the number of decimal places and watch each rounding direction update live. The last line shows Round wrapping a <code>Cast</code> expression: the value is doubled, cast to a number, then rounded up.</p>


### PR DESCRIPTION
Documentation for the new **`Round(value, digits, mode)`** function added in spadrapo/drapo#668 (code PR: spadrapo/drapo#669).

Adds `functions/Round/`:

- **description.html** — signature and the three modes (`round` nearest/ties-away-from-zero, `floor` toward −∞, `ceiling` toward +∞), decimal-place `digits`, and composition with `Cast`/`UpdateItemField`.
- **parameters.json** — `value` (required), `digits` (optional, default 0), `mode` (optional, default `round`).
- **samples/001/** — interactive sample: edit value + digits and watch nearest/floor/ceiling update live, plus a `Round(Cast(...))` example.

Tracking issue: spadrapo/drapo#668

🤖 Generated with [Claude Code](https://claude.com/claude-code)