### PR TITLE
CI: remove obsolete Fast Webhook (old App Service deploy)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,14 +29,6 @@ jobs:
         file: ./src/Dockerfile
         tags: ghcr.io/spadrapo/docs:latest
 
-    - name: Fast Webhook
-      # uses: jasongitmail/fast-webhook@6deed6ce6c4f3b7044a27fc272b7a019a6e4c41a
-      uses: jasongitmail/fast-webhook@v1.1.4
-      continue-on-error: true
-      with:
-        # URL (contains a credential) stored as a repo secret, not committed.
-        url: ${{ secrets.FAST_WEBHOOK_URL }}
-
   # After a successful image build, trigger the AKS deploy. The deploy itself
   # lives in the t6-enterprise/drapo repo, because only that org's self-hosted
   # runners have access to AKS — this (spadrapo) repo cannot reach the cluster.
@@ -60,12 +52,10 @@ jobs:
             echo "::error::DRAPO_DEPLOY_DISPATCH_TOKEN is not set — cannot trigger the AKS deploy."
             exit 1
           fi
-          # target_env=dev for now (prod needs its own federated credential set up
-          # in Azure first; flip to prd once prod is validated).
           curl -sSf -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $DISPATCH_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/t6-enterprise/drapo/dispatches \
-            -d '{"event_type":"deploy-drapo-docs","client_payload":{"target_env":"dev"}}'
-          echo "Triggered deploy-drapo-docs (target_env=dev) on t6-enterprise/drapo."
+            -d '{"event_type":"deploy-drapo-docs"}'
+          echo "Triggered deploy-drapo-docs on t6-enterprise/drapo."


### PR DESCRIPTION
## What
Removes the `Fast Webhook` step from the `build` job.

## Why
- The docs site is now served from **AKS** at **https://drapo.tech6cloud.com/**, deployed via `t6-enterprise/drapo` (triggered by this workflow's `trigger-deploy` job).
- The webhook pointed at an **Azure App Service** (`drapo.scm.azurewebsites.net`) that isn't found in any accessible subscription and is confirmed unused — so it's dead weight (and its URL held a credential).

## Also
- Simplified the `repository_dispatch` payload (deploy is dev-only; `target_env` no longer needed).

## Follow-up (manual)
- Delete the now-unused `FAST_WEBHOOK_URL` secret from this repo.
- Rotate that App Service publish credential in Azure (it was public in git history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)